### PR TITLE
fix pseudo element syntax

### DIFF
--- a/src/base.less
+++ b/src/base.less
@@ -2,8 +2,8 @@
 * {
   box-sizing: border-box;
 }
-*:before,
-*:after {
+*::before,
+*::after {
   box-sizing: border-box;
 }
 html {

--- a/src/menus.less
+++ b/src/menus.less
@@ -56,7 +56,7 @@
       z-index: 99;
     }
 
-    &:after {
+    &::after {
       content: "";
       display: block;
       width: 100%;


### PR DESCRIPTION
> The double colon replaced the single-colon notation for pseudo-elements in CSS3. This was an attempt from W3C to distinguish between pseudo-classes and pseudo-elements.