### PR TITLE
Fix pixelated edges around badges in Firefox

### DIFF
--- a/src/badges.less
+++ b/src/badges.less
@@ -4,6 +4,7 @@
 
   &::after {
     background: @core-color;
+    background-clip: padding-box;
     border: .1rem solid #fff;
     border-radius: 1rem;
     color: @core-text-color;


### PR DESCRIPTION
By adding the background-clip property and setting it to padding-box the pixelated edges around the badges in Firefox will be removed and the badges look smoother.