### PR TITLE
Add "chip-variant" for chip- success | danger | warning | default

### DIFF
--- a/src/chips.less
+++ b/src/chips.less
@@ -8,7 +8,6 @@
   list-style: none;
   margin: 0;
   padding: .5rem 0;
-
   .chip-icon {
     flex: 0 0 auto;
   }
@@ -32,9 +31,9 @@
 // Small chips
 .chip-sm {
   align-items: center;
-  background: @core-secondary-color;
+  background: transparent;
   border-radius: .3rem;
-  color: #666;
+  color: lighten(@body-font-color, 20%);
   display: inline-flex;
   font-size: 1.2rem;
   height: 2.4rem;
@@ -42,7 +41,18 @@
   padding: .3rem .6rem;
   text-decoration: none;
   vertical-align: middle;
-
+  &.chip-primary {
+    .chip-variant(@core-color);
+  }
+  &.chip-success {
+    .chip-variant(@control-color-success);
+  }
+  &.chip-danger {
+    .chip-variant(@control-color-danger);
+  }
+  &.chip-warning {
+    .chip-variant(@control-color-warning);
+  }
   &:hover,
   &:focus {
     background: darken(@core-secondary-color, 2%);

--- a/src/variables.less
+++ b/src/variables.less
@@ -58,3 +58,7 @@
   background: @color;
   color: @core-light-color;
 }
+.chip-variant(@color) {
+  background: @color;
+  color: @core-light-color;
+}


### PR DESCRIPTION
Hi,
for my personal project I'm using your CSS framework and I realize that chip-variant is missing, so here it's my PR with "chip-variant" in **variables.less** and "chip-level" in **chips.less**.
I've also made transparent chip-sm background with a lighter text color because is more readable.
Hope this help.
Thanks.

p.