### PR TITLE
form-select is now fully responsive / navbar-brand added

### DIFF
--- a/src/forms.less
+++ b/src/forms.less
@@ -101,7 +101,7 @@
   border-radius: .3rem;
   font-size: 1.4rem;
   line-height: 1.6rem;
-  min-width: @control-min-width;
+  width: 100%;
   outline: 0;
   padding: .5rem .8rem;
   vertical-align: middle;

--- a/src/navbar.less
+++ b/src/navbar.less
@@ -11,3 +11,16 @@
     padding: 1rem 0;
   }
 }
+.navbar-brand {
+  font-size: 2rem;
+  font-weight: bold;
+  padding-right: 2rem;
+  text-decoration: none;
+  vertical-align: middle;
+}
+.navbar-brand .icon {
+  font-size: 1.3333em;
+  line-height: .8em;
+  margin-right: .2rem;
+  vertical-align: -20%;
+}


### PR DESCRIPTION
I noticed that form-select was not very responsive due to min-width. I removed it and replaced it with 100% width to mimic form-input behavior so it follows its grid container size.

I also added the navbar-brand css code found in the official example page to navbar.less since it was missing.

Sorry about having 2 separate issues in one PR.. new to github :D