### PR TITLE
Add navbar-brand styling from documentation

### DIFF
--- a/src/navbar.less
+++ b/src/navbar.less
@@ -9,5 +9,20 @@
     align-items: center;
     display: flex;
     padding: 1rem 0;
+
+    .navbar-brand {
+      font-size: 2rem;
+      font-weight: bold;
+      padding-right: 2rem;
+      text-decoration: none;
+      vertical-align: middle;
+
+      .icon {
+        font-size: 1.3333em;
+        line-height: .8em;
+        margin-right: .2rem;
+        vertical-align: -20%;
+      }
+    }
   }
 }


### PR DESCRIPTION
Hi, this is a quick change to add the `.navbar-brand` and `.navbar-brand .icon` styling from the [documentation site's](https://picturepan2.github.io/spectre/#navbar) `<head><style>` into the project.

Thanks for Spectre.css!