### PR TITLE
Added BrowserSync for development

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -170,6 +170,7 @@
               <li>You can find compiled CSS files in <code>/dist</code> directory.</li>
             </ol>
             <p>You can watch file changes and rebuild CSS files by using <code>gulp watch</code>.</p>
+            <p>You can also start a development server with BrowserSync that will watch file changes and rebuild CSS using <code>gulp server</code>.</p>
           </section>
 
 <!-- file structure -->

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,18 +1,31 @@
 var gulp = require('gulp');
 var less = require('gulp-less');
+var browserSync = require('browser-sync').create()
 var cleancss = require('gulp-clean-css');
 var csscomb = require('gulp-csscomb');
 var rename = require('gulp-rename');
 var LessPluginAutoPrefix = require('less-plugin-autoprefix');
 
-var autoprefix= new LessPluginAutoPrefix({ browsers: ["last 4 versions"] });
+var autoprefix = new LessPluginAutoPrefix({
+    browsers: ["last 4 versions"]
+});
 
-gulp.task('watch', function() {
+gulp.task('server', ['watch'], function () {
+    browserSync.init({
+        files: ['./docs/**/*', './dist/**/*'],
+        logPrefix: 'Spectre',
+        server: {
+            baseDir: './docs'
+        }
+    })
+});
+
+gulp.task('watch', function () {
     gulp.watch('./**/*.less', ['build']);
     gulp.watch('./**/*.less', ['docs']);
 });
 
-gulp.task('build', function() {
+gulp.task('build', function () {
     gulp.src('./*.less')
         .pipe(less({
             plugins: [autoprefix]
@@ -26,7 +39,7 @@ gulp.task('build', function() {
         .pipe(gulp.dest('./dist'))
 });
 
-gulp.task('docs', function() {
+gulp.task('docs', function () {
     gulp.src(['./docs/css/*.less', './*.less'])
         .pipe(less({
             plugins: [autoprefix]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 var gulp = require('gulp');
 var less = require('gulp-less');
-var browserSync = require('browser-sync').create()
+var browserSync = require("browser-sync").create();
 var cleancss = require('gulp-clean-css');
 var csscomb = require('gulp-csscomb');
 var rename = require('gulp-rename');
@@ -17,7 +17,7 @@ gulp.task('server', ['watch'], function () {
         server: {
             baseDir: './docs'
         }
-    })
+    });
 });
 
 gulp.task('watch', function () {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/picturepan2/spectre/issues"
   },
   "devDependencies": {
+    "browser-sync": "^2.18.8",
     "gulp": "^3.9.1",
     "gulp-clean-css": "^3.0.3",
     "gulp-csscomb": "^3.0.8",


### PR DESCRIPTION
Added the option to run ```gulp server``` that will start browser sync and watch files within the ```./docs``` and ```./dist``` folders. 

The ```gulp server``` task will run ```gulp watch``` automatically. 

I feel this would be a nice development addition and doesn't affect the current workflow in anyway.