### PR TITLE
Added CDN link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Download the compiled and minified [Spectre CSS file](https://github.com/picture
 ##### Install with Yarn
 `$ yarn add spectre.css`
 
+##### Include the stylesheet from CDN
+`<link rel="stylesheet" href="unpkg.com/spectre.css/docs/dist/spectre.min.css" />`
+
 ##### Install with Bower
 `$ bower install spectre.css --save`
 


### PR DESCRIPTION
Unpkg link is currently the fastest way to try out a CSS or JS library. I've used it frequently with codepen.io and so I added the link to readme for benefit of others.