### PR TITLE
Forced font-family on tooltips to avoid wrong font inheritance.

### DIFF
--- a/src/tooltips.less
+++ b/src/tooltips.less
@@ -8,6 +8,7 @@
     color: @light-color;
     content: attr(data-tooltip);
     display: block;
+    font-family: @body-font-family;
     font-size: @font-size-sm;
     left: 50%;
     max-width: 32rem;


### PR DESCRIPTION
As stated in #200, tooltip fonts are inherited from the parents. It's an issue when the content uses a custom font, as it breaks the overall look. (i.e: fontawesome icons).