### PR TITLE
Fixed incorrect bower main path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "repository": "picturepan2/spectre",
   "license": "MIT",
   "author": "Yan Zhu <picturepan2@hotmail.com>",
-  "main": "dist/spectre.css",
+  "main": "docs/dist/spectre.css",
   "keywords": [
     "css",
     "framework",


### PR DESCRIPTION
You've moved spectre.css from `dist/` to `docs/dist/`, but didn't reflect that change to bower.json's `main` property. 
This leads to for example [`wiredep`](https://github.com/taptapship/wiredep) being unable to find the spectre.css file, which is unfortunately breaking my grunt build. 😛

This PR fixes the path in bower.json's main property.
Thanks for the work on Spectre.css! 👍 