### PR TITLE
[Proof of concept] Add support of customizing via css variables

### DIFF
--- a/docs/src/docs.less
+++ b/docs/src/docs.less
@@ -1,5 +1,10 @@
 /*! Spectre.css Docs | MIT License | github.com/picturepan2/spectre */
 /* Spectre version */
+:root {
+  --spectre-html-font-size: 1rem;
+  --spectre-primary-color: red;
+}
+
 .version::after {
   content: "0.2.14";
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
   "bugs": {
     "url": "https://github.com/picturepan2/spectre/issues"
   },
+  "scripts": {
+    "build": "gulp build",
+    "docs": "gulp docs",
+    "watch": "gulp watch"
+  },
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-clean-css": "^3.0.3",

--- a/spectre.less
+++ b/spectre.less
@@ -2,6 +2,7 @@
 
 // Core variables and mixins
 @import 'src/variables.less';
+@import 'src/css-variables.less';
 @import 'src/mixins.less';
 
 // Reset and dependencies

--- a/src/badges.less
+++ b/src/badges.less
@@ -6,6 +6,7 @@
   &[data-badge],
   &:not([data-badge]) {
     &::after {
+      background: var(--spectre-primary-color);
       background: @primary-color;
       background-clip: padding-box;
       border-radius: 1rem;

--- a/src/base.less
+++ b/src/base.less
@@ -7,6 +7,7 @@
 
 html {
   box-sizing: border-box;
+  font-size: var(--spectre-html-font-size);
   font-size: @html-font-size;
   line-height: @html-line-height;
   -webkit-tap-highlight-color: transparent;

--- a/src/css-variables.less
+++ b/src/css-variables.less
@@ -1,0 +1,4 @@
+:root {
+  --spectre-html-font-size: @html-font-size;
+  --spectre-primary-color: @primary-color;
+}


### PR DESCRIPTION
### Rationale

There is a need of customizing variables in `spectre.css`. Currently you need to setup LESS workflow to be able to do that. This is not convenient. It is possible to maintain list of the LESS variables along with a list of the [css custom properies](https://www.w3.org/TR/css-variables/). Custom properties have a [70%+ support](http://caniuse.com/#feat=css-variables), which is fine, if you are targeting only modern browsers.

### Implementation

* Additional file (in my case, `css-variables.less`) should contain all LESS variables, mapped to custom properties, that are set on the `:root` selector. This list can be maintained manually or automatically.
* Each usage of the LESS variable should be accompanied with same rule with custom-property. Browsers that can use custom properties will use them and others will use default values provided from LESS variables as fallback. Preferably this code modification should be done automatically.
* After inclusion of the `spectre.css`, we need to provide css file that will redefine custom properties. In this example this is `docs/src/docs.less`

### Demo
Run `gulp docs` or `npm/yarn docs` to build docs. Open `index.html` in docs directory.
Expected font-size to increased to `1rem` and badge component background to be `red`

### Short-comings
If browser does not support custom properties, it will use values provided by LESS variables. In case of considerable difference between redefined custom properties and LESS variables. This can lead to completely broken styling for unsupported browsers.