### PR TITLE
Optimize Japanese font family

### DIFF
--- a/src/asian.less
+++ b/src/asian.less
@@ -1,9 +1,12 @@
 // Optimized for East Asian CJK
 :lang(zh),
-:lang(ja),
 :lang(ko),
 .cjk {
   font-family: @cjk-font-family;
+}
+
+:lang(ja) {
+  font-family: @cjk-jp-font-family;
 }
 
 :lang(zh),

--- a/src/variables.less
+++ b/src/variables.less
@@ -13,6 +13,7 @@
 // Credit: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/
 @base-font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto;
 @fallback-font-family: "Helvetica Neue", sans-serif;
+@cjk-jp-font-family: @base-font-family, "Hiragino Sans", "Hiragino Kaku Gothic Pro", "Yu Gothic", YuGothic, Meiryo, @fallback-font-family;
 @cjk-font-family: @base-font-family, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Hiragino Kaku Gothic Pro", Meiryo, "Malgun Gothic", @fallback-font-family;
 @body-font-family: @base-font-family, @fallback-font-family;
 


### PR DESCRIPTION
Fix wrong Japanese font family in `lang="jp"` defined.

![2017-06-17 15 54 30](https://user-images.githubusercontent.com/2971112/27250894-5d8efddc-5375-11e7-8244-bc2ef08521e9.png)
