### PR TITLE
Fix document about experimentals/off-canvas

### DIFF
--- a/docs/experimentals.html
+++ b/docs/experimentals.html
@@ -790,7 +790,7 @@
   &lt;<span class="tag">div</span> <span class="atn">class</span>=<span class="atv">&quot;off-canvas-sidebar&quot;</span>&gt;
     <span class="com">&lt;!-- off-screen sidebar --&gt;</span>
   &lt;<span class="tag">/div</span>&gt;
-  &lt;<span class="tag">div</span> <span class="atn">class</span>=<span class="atv">&quot;off-canvas-body&quot;</span>&gt;
+  &lt;<span class="tag">div</span> <span class="atn">class</span>=<span class="atv">&quot;off-canvas-content&quot;</span>&gt;
     <span class="com">&lt;!-- off-screen content --&gt;</span>
   &lt;<span class="tag">/div</span>&gt;
 &lt;<span class="tag">/div</span>&gt;


### PR DESCRIPTION
There is no such a class ``off-canvas-body``.
This commit replaces ``off-canvas-body`` with ``off-canvas-content`` in the document.