### PR TITLE
Fix limited height body of accordion

### DIFF
--- a/src/_accordions.scss
+++ b/src/_accordions.scss
@@ -9,7 +9,7 @@
     }
 
     & .accordion-body {
-      max-height: 50rem;
+      max-height: initial;
     }
   }
 


### PR DESCRIPTION
Previously, accordion body's were limited to 50em. This changes makes
allows them to work up to any height.