### PR TITLE
Use padding instead of margin to remove gap

### DIFF
--- a/src/_timelines.scss
+++ b/src/_timelines.scss
@@ -2,7 +2,7 @@
 .timeline {
   .timeline-item {
     display: flex;
-    margin-bottom: $unit-6;
+    padding-bottom: $unit-6;
     position: relative;
     &::before {
       background: $border-color;


### PR DESCRIPTION
In the timeline, below the little circle on the left (left of March 2016 on this page: https://picturepan2.github.io/spectre/experimentals.html#timelines) is a gap/white space. I'm not sure if this is intentional or not, but I fixed it on my project by replacing margin-bottom by padding-bottom.

Now the gap is gone and I think it looks much better.