### PR TITLE
Optional class names prefix

### DIFF
--- a/dist/spectre-exp.css
+++ b/dist/spectre-exp.css
@@ -213,7 +213,7 @@
   border-right: 0;
 }
 
-.calendar.calendar-lg .calendar-body .calendar-date:nth-last-child(-n+7) {
+.calendar.calendar-lg .calendar-body .calendar-date:nth-last-child(-n + 7) {
   border-bottom: 0;
 }
 

--- a/dist/spectre.css
+++ b/dist/spectre.css
@@ -2491,7 +2491,7 @@ summary.accordion-header::-webkit-details-marker {
 .modal-container {
   background: #fff;
   border-radius: .1rem;
-  box-shadow: 0 .2rem .5rem rgba(69, 77, 93, .3);
+  box-shadow: 0 .2rem .5rem rgba(69, 77, 93, .3); 
   display: block;
   padding: 0 .8rem;
 }

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -579,7 +579,7 @@
 </code></pre>
 
         <div class="docs-note">
-          <p>To add <code>spectre-</code> to all classes, you can add the Gulp task to <code>gulpfile.js</code> file.</p>
+          <p>To add <code>spectre-</code> to all classes in a postprocessing step, you can add the Gulp task to <code>gulpfile.js</code> file.</p>
         </div>
 
 <!-- custom prefix -->
@@ -594,6 +594,12 @@ gulp.task('prefix', function() {
 
         <div class="docs-note">
           <p>After you compile your version of Spectre in the /dist, run <code>gulp prefix</code> in the directory of Spectre.</p>
+        </div>
+
+        <h6>When using SASS</h6>
+
+        <div class="docs-note">
+          <p>If you use the Sass source files, you can set <code>$prefix</code> to <code>spectre-</code> to get the same result.</p>
         </div>
       </div>
 

--- a/src/_accordions.scss
+++ b/src/_accordions.scss
@@ -1,5 +1,5 @@
 // Accordions
-.accordion {
+.#{$prefix}accordion {
   input:checked ~,
   &[open] {
     & .accordion-header {

--- a/src/_animations.scss
+++ b/src/_animations.scss
@@ -1,5 +1,5 @@
 // Animations
-@keyframes loading {
+@keyframes #{$prefix}loading {
   0% {
     transform: rotate(0deg);
   }
@@ -8,7 +8,7 @@
   }
 }
 
-@keyframes slide-down {
+@keyframes #{$prefix}slide-down {
   0% {
     opacity: 0;
     transform: translateY(-$unit-8);

--- a/src/_asian.scss
+++ b/src/_asian.scss
@@ -13,7 +13,7 @@
 
 :lang(zh),
 :lang(ja),
-.cjk {
+.#{$prefix}cjk {
   ins,
   u {
     border-bottom: $border-width solid;

--- a/src/_autocomplete.scss
+++ b/src/_autocomplete.scss
@@ -1,8 +1,8 @@
 // Autocomplete
-.form-autocomplete {
+.#{$prefix}form-autocomplete {
   position: relative;
 
-  .form-autocomplete-input {
+  .#{$prefix}form-autocomplete-input {
     align-content: flex-start;
     display: flex;
     flex-wrap: wrap;
@@ -10,12 +10,12 @@
     min-height: $unit-8;
     padding: $unit-h;
 
-    &.is-focused {
+    &.#{$prefix}is-focused {
       @include control-shadow();
       border-color: $primary-color;
     }
 
-    .form-input {
+    .#{$prefix}form-input {
       border-color: transparent;
       box-shadow: none;
       display: inline-block;
@@ -27,20 +27,20 @@
     }
   }
 
-  .menu {
+  .#{$prefix}menu {
     left: 0;
     position: absolute;
     top: 100%;
     width: 100%;
   }
 
-  &.autocomplete-oneline {
-    .form-autocomplete-input {
+  &.#{$prefix}autocomplete-oneline {
+    .#{$prefix}form-autocomplete-input {
       flex-wrap: nowrap;
       overflow-x: auto;
     }
 
-    .chip {
+    .#{$prefix}chip {
       flex: 1 0 auto;
     }
   }

--- a/src/_avatars.scss
+++ b/src/_avatars.scss
@@ -1,5 +1,5 @@
 // Avatars
-.avatar {
+.#{$prefix}avatar {
   @include avatar-base();
   background: $primary-color;
   border-radius: 50%;
@@ -11,16 +11,16 @@
   position: relative;
   vertical-align: middle;
 
-  &.avatar-xs {
+  &.#{$prefix}avatar-xs {
     @include avatar-base($unit-4);
   }
-  &.avatar-sm {
+  &.#{$prefix}avatar-sm {
     @include avatar-base($unit-6);
   }
-  &.avatar-lg {
+  &.#{$prefix}avatar-lg {
     @include avatar-base($unit-12);
   }
-  &.avatar-xl {
+  &.#{$prefix}avatar-xl {
     @include avatar-base($unit-16);
   }
 
@@ -32,8 +32,8 @@
     z-index: $zindex-0;
   }
 
-  .avatar-icon,
-  .avatar-presence {
+  .#{$prefix}avatar-icon,
+  .#{$prefix}avatar-presence {
     background: $bg-color-light;
     bottom: 14.64%;
     height: 50%;
@@ -45,29 +45,29 @@
     z-index: $zindex-0 + 1;
   }
 
-  .avatar-presence {
+  .#{$prefix}avatar-presence {
     background: $gray-color;
     box-shadow: 0 0 0 $border-width-lg $light-color;
     border-radius: 50%;
     height: .5em;
     width: .5em;
 
-    &.online {
+    &.#{$prefix}online {
       background: $success-color;
     }
 
-    &.busy {
+    &.#{$prefix}busy {
       background: $error-color;
     }
 
-    &.away {
+    &.#{$prefix}away {
       background: $warning-color;
     }
   }
 
-  &[data-initial]::before {
+  &[data-#{$prefix}initial]::before {
     color: currentColor;
-    content: attr(data-initial);
+    content: attr(data-#{$prefix}initial);
     left: 50%;
     position: absolute;
     top: 50%;

--- a/src/_badges.scss
+++ b/src/_badges.scss
@@ -1,10 +1,10 @@
 // Badges
-.badge {
+.#{$prefix}badge {
   position: relative;
   white-space: nowrap;
 
-  &[data-badge],
-  &:not([data-badge]) {
+  &[data-#{$prefix}badge],
+  &:not([data-#{$prefix}badge]) {
     &::after {
       background: $primary-color;
       background-clip: padding-box;
@@ -16,7 +16,8 @@
       transform: translate(-.1rem, -.5rem);
     }
   }
-  &[data-badge] {
+
+  &[data-#{$prefix}badge] {
     &::after {
       font-size: $font-size-sm;
       height: .9rem;
@@ -27,8 +28,9 @@
       white-space: nowrap;
     }
   }
-  &:not([data-badge]),
-  &[data-badge=""] {
+
+  &:not([data-#{$prefix}badge]),
+  &[data-#{$prefix}badge=""] {
     &::after {
       height: 6px;
       min-width: 6px;

--- a/src/_bars.scss
+++ b/src/_bars.scss
@@ -1,5 +1,5 @@
 // Bars
-.bar {
+.#{$prefix}bar {
   background: $bg-color-dark;
   border-radius: $border-radius;
   display: flex;
@@ -7,12 +7,12 @@
   height: $unit-4;
   width: 100%;
 
-  &.bar-sm {
+  &.#{$prefix}bar-sm {
     height: $unit-1;
   }
 
   // TODO: attr() support
-  .bar-item {
+  .#{$prefix}bar-item {
     background: $primary-color;
     color: $light-color;
     display: block;
@@ -28,6 +28,7 @@
       border-bottom-left-radius: $border-radius;
       border-top-left-radius: $border-radius;
     }
+
     &:last-child {
       border-bottom-right-radius: $border-radius;
       border-top-right-radius: $border-radius;
@@ -37,22 +38,23 @@
 }
 
 // Slider bar
-.bar-slider {
+.#{$prefix}bar-slider {
   height: $border-width-lg;
   margin: $layout-spacing 0;
   position: relative;
 
-  .bar-item {
+  .#{$prefix}bar-item {
     left: 0;
     padding: 0;
     position: absolute;
+
     &:not(:last-child):first-child {
       background: $bg-color-dark;
       z-index: $zindex-0;
     }
   }
 
-  .bar-slider-btn {
+  .#{$prefix}bar-slider-btn {
     background: $primary-color;
     border: 0;
     border-radius: 50%;
@@ -65,7 +67,7 @@
     width: $unit-3;
 
     &:active {
-      box-shadow: 0 0 0 .1rem $primary-color;
+      box-shadow: 0 0 0 0.1rem $primary-color;
     }
   }
 }

--- a/src/_breadcrumbs.scss
+++ b/src/_breadcrumbs.scss
@@ -1,10 +1,10 @@
 // Breadcrumbs
-.breadcrumb {
+.#{$prefix}breadcrumb {
   list-style: none;
   margin: $unit-1 0;
   padding: $unit-1 0;
 
-  .breadcrumb-item {
+  .#{$prefix}breadcrumb-item {
     color: $gray-color-dark;
     display: inline-block;
     margin: 0;

--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -1,5 +1,5 @@
 // Buttons
-.btn {
+.#{$prefix}btn {
   @include control-transition();
   appearance: none;
   background: $bg-color-light;
@@ -18,38 +18,43 @@
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
+
   &:focus {
     @include control-shadow();
   }
+
   &:focus,
   &:hover {
     background: $secondary-color;
     border-color: $primary-color-dark;
     text-decoration: none;
   }
+
   &:active,
   &.active {
     background: $primary-color-dark;
     border-color: darken($primary-color-dark, 5%);
     color: $light-color;
     text-decoration: none;
-    &.loading {
+
+    &.#{$prefix}loading {
       &::after {
         border-bottom-color: $light-color;
         border-left-color: $light-color;
       }
     }
   }
+
   &[disabled],
   &:disabled,
   &.disabled {
     cursor: default;
-    opacity: .5;
+    opacity: 0.5;
     pointer-events: none;
   }
 
   // Button Primary
-  &.btn-primary {
+  &.#{$prefix}btn-primary {
     background: $primary-color;
     border-color: $primary-color-dark;
     color: $light-color;
@@ -74,16 +79,16 @@
   }
 
   // Button Colors
-  &.btn-success {
+  &.#{$prefix}btn-success {
     @include button-variant($success-color);
   }
 
-  &.btn-error {
+  &.#{$prefix}btn-error {
     @include button-variant($error-color);
   }
 
   // Button Link
-  &.btn-link {
+  &.#{$prefix}btn-link {
     background: transparent;
     border-color: transparent;
     color: $link-color;
@@ -96,41 +101,41 @@
   }
 
   // Button Sizes
-  &.btn-sm {
+  &.#{$prefix}btn-sm {
     font-size: $font-size-sm;
     height: $control-size-sm;
     padding: $control-padding-y-sm $control-padding-x-sm;
   }
 
-  &.btn-lg {
+  &.#{$prefix}btn-lg {
     font-size: $font-size-lg;
     height: $control-size-lg;
     padding: $control-padding-y-lg $control-padding-x-lg;
   }
 
   // Button Block
-  &.btn-block {
+  &.#{$prefix}btn-block {
     display: block;
     width: 100%;
   }
 
   // Button Action
-  &.btn-action {
+  &.#{$prefix}btn-action {
     width: $control-size;
     padding-left: 0;
     padding-right: 0;
 
-    &.btn-sm {
+    &.#{$prefix}btn-sm {
       width: $control-size-sm;
     }
 
-    &.btn-lg {
+    &.#{$prefix}btn-lg {
       width: $control-size-lg;
     }
   }
 
   // Button Clear
-  &.btn-clear {
+  &.#{$prefix}btn-clear {
     background: transparent;
     border: 0;
     color: currentColor;
@@ -144,7 +149,7 @@
     width: $unit-4;
 
     &:hover {
-      opacity: .95;
+      opacity: 0.95;
     }
 
     &::before {
@@ -154,37 +159,41 @@
 }
 
 // Button groups
-.btn-group {
+.#{$prefix}btn-group {
   display: inline-flex;
   flex-wrap: wrap;
 
-  .btn {
+  .#{$prefix}btn {
     flex: 1 0 auto;
+
     &:first-child:not(:last-child) {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
     }
+
     &:not(:first-child):not(:last-child) {
       border-radius: 0;
       margin-left: -$border-width;
     }
+
     &:last-child:not(:first-child) {
       border-bottom-left-radius: 0;
       border-top-left-radius: 0;
       margin-left: -$border-width;
     }
+
     &:focus,
     &:hover,
     &:active,
-    &.active {
+    &.#{$prefix}active {
       z-index: $zindex-0;
     }
   }
 
-  &.btn-group-block {
+  &.#{$prefix}btn-group-block {
     display: flex;
 
-    .btn {
+    .#{$prefix}btn {
       flex: 1 0 0;
     }
   }

--- a/src/_calendars.scss
+++ b/src/_calendars.scss
@@ -1,11 +1,11 @@
 // Calendars
-.calendar {
+.#{$prefix}calendar {
   border: $border-width solid $border-color;
   border-radius: $border-radius;
   display: block;
   min-width: 280px;
 
-  .calendar-nav {
+  .#{$prefix}calendar-nav {
     align-items: center;
     background: $bg-color;
     border-top-left-radius: $border-radius;
@@ -15,20 +15,20 @@
     padding: $layout-spacing;
   }
 
-  .calendar-header,
-  .calendar-body {
+  .#{$prefix}calendar-header,
+  .#{$prefix}calendar-body {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
     padding: $layout-spacing 0;
 
-    .calendar-date {
+    .#{$prefix}calendar-date {
       flex: 0 0 14.28%; // 7 calendar-items each row
       max-width: 14.28%;
     }
   }
 
-  .calendar-header {
+  .#{$prefix}calendar-header {
     background: $bg-color;
     border-bottom: $border-width solid $border-color;
     color: $gray-color;
@@ -36,15 +36,15 @@
     text-align: center;
   }
 
-  .calendar-body {
+  .#{$prefix}calendar-body {
     color: $gray-color-dark;
   }
 
-  .calendar-date {
+  .#{$prefix}calendar-date {
     border: 0;
     padding: $unit-1;
 
-    .date-item {
+    .#{$prefix}date-item {
       @include control-transition();
       appearance: none;
       background: transparent;
@@ -64,7 +64,7 @@
       white-space: nowrap;
       width: $unit-7;
 
-      &.date-today {
+      &.#{$prefix}date-today {
         border-color: $secondary-color-dark;
         color: $primary-color;
       }
@@ -81,14 +81,14 @@
         text-decoration: none;
       }
       &:active,
-      &.active {
+      &.#{$prefix}active {
         background: $primary-color-dark;
         border-color: darken($primary-color-dark, 5%);
         color: $light-color;
       }
 
       // Calendar badge support
-      &.badge {
+      &.#{$prefix}badge {
         &::after {
           position: absolute;
           top: 3px;
@@ -98,17 +98,17 @@
       }
     }
 
-    &.disabled .date-item,
-    &.disabled .calendar-event,
-    .date-item:disabled,
-    .calendar-event:disabled {
+    &.#{$prefix}disabled .#{$prefix}date-item,
+    &.#{$prefix}disabled .#{$prefix}calendar-event,
+    .#{$prefix}date-item:disabled,
+    .#{$prefix}calendar-event:disabled {
       cursor: default;
       opacity: .25;
       pointer-events: none;
     }
   }
 
-  .calendar-range {
+  .#{$prefix}calendar-range {
     position: relative;
 
     &::before {
@@ -121,27 +121,28 @@
       top: 50%;
       transform: translateY(-50%);
     }
-    &.range-start {
+
+    &.#{$prefix}range-start {
       &::before {
         left: 50%;
       }
     }
-    &.range-end {
+    &.#{$prefix}range-end {
       &::before {
         right: 50%;
       }
     }
 
-    .date-item {
+    .#{$prefix}date-item {
       color: $primary-color;
     }
   }
 
-  &.calendar-lg {
-    .calendar-body {
+  &.#{$prefix}calendar-lg {
+    .#{$prefix}calendar-body {
       padding: 0;
 
-      .calendar-date {
+      .#{$prefix}calendar-date {
         border-bottom: $border-width solid $border-color;
         border-right: $border-width solid $border-color;
         display: flex;
@@ -152,44 +153,44 @@
         &:nth-child(7n) {
           border-right: 0;
         }
-        &:nth-last-child(-n+7) {
+        &:nth-last-child(-n + 7) {
           border-bottom: 0;
         }
       }
     }
 
-    .date-item {
+    .#{$prefix}date-item {
       align-self: flex-end;
       height: $unit-7;
       margin-right: $layout-spacing-sm;
       margin-top: $layout-spacing-sm;
     }
 
-    .calendar-range {
+    .#{$prefix}calendar-range {
       &::before {
         top: 19px;
       }
-      &.range-start {
+      &.#{$prefix}range-start {
         &::before {
           left: auto;
           width: 19px;
         }
       }
-      &.range-end {
+      &.#{$prefix}range-end {
         &::before {
           right: 19px;
         }
       }
     }
 
-    .calendar-events {
+    .#{$prefix}calendar-events {
       flex-grow: 1;
       line-height: 1;
       overflow-y: auto;
       padding: $layout-spacing-sm;
     }
 
-    .calendar-event {
+    .#{$prefix}calendar-event {
       border-radius: $border-radius;
       font-size: $font-size-sm;
       display: block;

--- a/src/_cards.scss
+++ b/src/_cards.scss
@@ -1,14 +1,14 @@
 // Cards
-.card {
+.#{$prefix}card {
   background: $bg-color-light;
   border: $border-width solid $border-color;
   border-radius: $border-radius;
   display: flex;
   flex-direction: column;
 
-  .card-header,
-  .card-body,
-  .card-footer {
+  .#{$prefix}card-header,
+  .#{$prefix}card-body,
+  .#{$prefix}card-footer {
     padding: $layout-spacing-lg;
     padding-bottom: 0;
 
@@ -17,7 +17,7 @@
     }
   }
 
-  .card-image {
+  .#{$prefix}card-image {
     padding-top: $layout-spacing-lg;
 
     &:first-child {

--- a/src/_carousels.scss
+++ b/src/_carousels.scss
@@ -1,5 +1,5 @@
 // Carousels
-.carousel {
+.#{$prefix}carousel {
   background: $bg-color;
   display: block;
   overflow: hidden;
@@ -8,7 +8,7 @@
   -webkit-overflow-scrolling: touch;
   z-index: $zindex-0;
 
-  .carousel-container {
+  .#{$prefix}carousel-container {
     height: 100%;
     left: 0;
     position: relative;
@@ -18,8 +18,8 @@
       padding-bottom: 56.25%;
     }
 
-    .carousel-item {
-      animation: carousel-slideout 1s ease-in-out 1;
+    .#{$prefix}carousel-item {
+      animation: #{$prefix}carousel-slideout 1s ease-in-out 1;
       height: 100%;
       left: 0;
       margin: 0;
@@ -29,17 +29,17 @@
       width: 100%;
 
       &:hover {
-        .item-prev,
-        .item-next {
+        .#{$prefix}item-prev,
+        .#{$prefix}item-next {
           opacity: 1;
         }
       }
     }
 
-    .item-prev,
-    .item-next {
-      background: rgba($gray-color-light, .25);
-      border-color: rgba($gray-color-light, .5);
+    .#{$prefix}item-prev,
+    .#{$prefix}item-next {
+      background: rgba($gray-color-light, 0.25);
+      border-color: rgba($gray-color-light, 0.5);
       color: $gray-color-light;
       opacity: 0;
       position: absolute;
@@ -48,20 +48,20 @@
       transform: translateY(-50%);
       z-index: $zindex-1;
     }
-    .item-prev {
+    .#{$prefix}item-prev {
       left: 1rem;
     }
-    .item-next {
+    .#{$prefix}item-next {
       right: 1rem;
     }
   }
 
-  .carousel-locator {
+  .#{$prefix}carousel-locator {
     &:nth-of-type(1):checked ~ .carousel-container .carousel-item:nth-of-type(1),
     &:nth-of-type(2):checked ~ .carousel-container .carousel-item:nth-of-type(2),
     &:nth-of-type(3):checked ~ .carousel-container .carousel-item:nth-of-type(3),
     &:nth-of-type(4):checked ~ .carousel-container .carousel-item:nth-of-type(4) {
-      animation: carousel-slidein .75s ease-in-out 1;
+      animation: #{$prefix}carousel-slidein 0.75s ease-in-out 1;
       opacity: 1;
       z-index: $zindex-1;
     }
@@ -73,7 +73,7 @@
     }
   }
 
-  .carousel-nav {
+  .#{$prefix}carousel-nav {
     bottom: $layout-spacing;
     display: flex;
     justify-content: center;
@@ -83,8 +83,8 @@
     width: 10rem;
     z-index: $zindex-1;
 
-    .nav-item {
-      color: rgba($gray-color-light, .5);
+    .#{$prefix}nav-item {
+      color: rgba($gray-color-light, 0.5);
       display: block;
       flex: 1 0 auto;
       height: $unit-8;
@@ -98,14 +98,14 @@
         display: block;
         height: $unit-h;
         position: absolute;
-        top: .5rem;
+        top: 0.5rem;
         width: 100%;
       }
     }
   }
 }
 
-@keyframes carousel-slidein {
+@keyframes #{$prefix}carousel-slidein {
   0% {
     transform: translateX(100%);
   }
@@ -114,7 +114,7 @@
   }
 }
 
-@keyframes carousel-slideout {
+@keyframes #{$prefix}carousel-slideout {
   0% {
     opacity: 1;
     transform: translateX(0);

--- a/src/_chips.scss
+++ b/src/_chips.scss
@@ -1,5 +1,5 @@
 // Chips
-.chip {
+.#{$prefix}chip {
   align-items: center;
   background: $bg-color-dark;
   border-radius: 5rem;
@@ -14,12 +14,12 @@
   text-decoration: none;
   vertical-align: middle;
 
-  &.active {
+  &.#{$prefix}active {
     background: $primary-color;
     color: $light-color;
   }
 
-  .avatar {
+  .#{$prefix}avatar {
     margin-left: -$unit-2;
     margin-right: $unit-1;
   }

--- a/src/_codes.scss
+++ b/src/_codes.scss
@@ -5,7 +5,7 @@ code {
   font-size: 85%;
 }
 
-.code {
+.#{$prefix}code {
   border-radius: $border-radius;
   color: $body-font-color;
   position: relative;

--- a/src/_comparison-sliders.scss
+++ b/src/_comparison-sliders.scss
@@ -1,14 +1,14 @@
 // Image comparison slider
 // Credit: http://codepen.io/solipsistacp/pen/Gpmaq
-.comparison-slider {
+.#{$prefix}comparison-slider {
   height: 50vh;
   overflow: hidden;
   position: relative;
   width: 100%;
   -webkit-overflow-scrolling: touch;
 
-  .comparison-before,
-  .comparison-after {
+  .#{$prefix}comparison-before,
+  .#{$prefix}comparison-after {
     height: 100%;
     left: 0;
     margin: 0;
@@ -25,16 +25,16 @@
     }
   }
 
-  .comparison-before {
+  .#{$prefix}comparison-before {
     width: 100%;
     z-index: 1;
 
-    .comparison-label {
+    .#{$prefix}comparison-label {
       right: $unit-4;
     }
   }
 
-  .comparison-after {
+  .#{$prefix}comparison-after {
     max-width: 100%;
     min-width: 0;
     z-index: 2;
@@ -65,13 +65,13 @@
       width: 3px;
     }
 
-    .comparison-label {
+    .#{$prefix}comparison-label {
       left: $unit-4;
     }
   }
 
-  .comparison-resizer {
-    animation: first-run 1.5s 1 ease-in-out;
+  .#{$prefix}comparison-resizer {
+    animation: #{$prefix}first-run 1.5s 1 ease-in-out;
     cursor: ew-resize;
     height: $unit-4;
     left: 0;
@@ -86,17 +86,17 @@
     width: 0;
   }
 
-  .comparison-label {
-    background: rgba($dark-color, .5);
+  .#{$prefix}comparison-label {
     bottom: $unit-4;
     color: $light-color;
     padding: $unit-1 $unit-2;
+    background: rgba($dark-color, .5);
     position: absolute;
     user-select: none;
   }
 }
 
-@keyframes first-run {
+@keyframes #{$prefix}first-run {
   0% {
     width: 0;
   }

--- a/src/_dropdowns.scss
+++ b/src/_dropdowns.scss
@@ -1,10 +1,10 @@
 // Dropdown
-.dropdown {
+.#{$prefix}dropdown {
   display: inline-block;
   position: relative;
 
-  .menu {
-    animation: slide-down .15s ease 1;
+  .#{$prefix}menu {
+    animation: #{$prefix}slide-down 0.15s ease 1;
     display: none;
     left: 0;
     max-height: 50vh;
@@ -13,22 +13,22 @@
     top: 100%;
   }
 
-  &.dropdown-right {
-    .menu {
+  &.#{$prefix}dropdown-right {
+    .#{$prefix}menu {
       left: auto;
       right: 0;
     }
   }
 
-  &.active .menu,
-  .dropdown-toggle:focus + .menu,
-  .menu:hover {
+  &.#{$prefix}active .#{$prefix}menu,
+  .#{$prefix}dropdown-toggle:focus + .#{$prefix}menu,
+  .#{$prefix}menu:hover {
     display: block;
   }
 
   // Fix dropdown-toggle border radius in button groups
-  .btn-group {
-    .dropdown-toggle:nth-last-child(2) {
+  .#{$prefix}btn-group {
+    .#{$prefix}dropdown-toggle:nth-last-child(2) {
       border-bottom-right-radius: $border-radius;
       border-top-right-radius: $border-radius;
     }

--- a/src/_empty.scss
+++ b/src/_empty.scss
@@ -1,21 +1,21 @@
 // Empty states (or Blank slates)
-.empty {
+.#{$prefix}empty {
   background: $bg-color;
   border-radius: $border-radius;
   color: $gray-color-dark;
   text-align: center;
   padding: $unit-16 $unit-8;
 
-  .empty-icon {
+  .#{$prefix}empty-icon {
     margin-bottom: $layout-spacing-lg;
   }
 
-  .empty-title,
-  .empty-subtitle {
+  .#{$prefix}empty-title,
+  .#{$prefix}empty-subtitle {
     margin: $layout-spacing auto;
   }
 
-  .empty-action {
+  .#{$prefix}empty-action {
     margin-top: $layout-spacing-lg;
   }
 }

--- a/src/_filters.scss
+++ b/src/_filters.scss
@@ -1,35 +1,37 @@
-// Filters 
-// The number of filter options 
+// Filters
+// The number of filter options
 $filter-number: 8 !default;
 
-%filter-checked-nav { 
+%filter-checked-nav {
   background: $primary-color;
   color: $light-color;
 }
 
-%filter-checked-body { 
+%filter-checked-body {
   display: none;
 }
 
-.filter {
-  .filter-nav {
+.#{$prefix}filter {
+  .#{$prefix}filter-nav {
     margin: $layout-spacing 0;
   }
 
-  .filter-body {
+  .#{$prefix}filter-body {
     display: flex;
     flex-wrap: wrap;
   }
 
-  .filter-tag {
+  .#{$prefix}filter-tag {
     @for $i from 0 through ($filter-number) {
-      &#tag-#{$i}:checked ~ .filter-nav .chip[for="tag-#{$i}"] {
+      &##{$prefix}tag-#{$i}:checked ~ .#{$prefix}filter-nav .#{$prefix}chip[for="tag-#{$i}"] {
         @extend %filter-checked-nav;
       }
     }
 
     @for $i from 1 through ($filter-number) {
-      &#tag-#{$i}:checked ~ .filter-body .filter-item:not([data-tag~="tag-#{$i}"]) {
+      &##{$prefix}tag-#{$i}:checked
+        ~ .#{$prefix}filter-body
+        .#{$prefix}filter-item:not([data-#{$prefix}tag~="tag-#{$i}"]) {
         @extend %filter-checked-body;
       }
     }

--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -1,5 +1,5 @@
 // Forms
-.form-group {
+.#{$prefix}form-group {
   &:not(:last-child) {
     margin-bottom: $layout-spacing;
   }
@@ -16,24 +16,24 @@ legend {
 }
 
 // Form element: Label
-.form-label {
+.#{$prefix}form-label {
   display: block;
   line-height: $line-height;
   padding: $control-padding-y + $border-width 0;
 
-  &.label-sm {
+  &.#{$prefix}label-sm {
     font-size: $font-size-sm;
     padding: $control-padding-y-sm + $border-width 0;
   }
 
-  &.label-lg {
+  &.#{$prefix}label-lg {
     font-size: $font-size-lg;
     padding: $control-padding-y-lg + $border-width 0;
   }
 }
 
 // Form element: Input
-.form-input {
+.#{$prefix}form-input {
   @include control-transition();
   appearance: none;
   background: $bg-color-light;
@@ -59,19 +59,19 @@ legend {
   }
 
   // Input sizes
-  &.input-sm {
+  &.#{$prefix}input-sm {
     font-size: $font-size-sm;
     height: $control-size-sm;
     padding: $control-padding-y-sm $control-padding-x-sm;
   }
 
-  &.input-lg {
+  &.#{$prefix}input-lg {
     font-size: $font-size-lg;
     height: $control-size-lg;
     padding: $control-padding-y-lg $control-padding-x-lg;
   }
 
-  &.input-inline {
+  &.#{$prefix}input-inline {
     display: inline-block;
     vertical-align: middle;
     width: auto;
@@ -84,29 +84,29 @@ legend {
 }
 
 // Form element: Textarea
-textarea.form-input {
+textarea.#{$prefix}form-input {
   height: auto;
 }
 
 // Form element: Input hint
-.form-input-hint {
+.#{$prefix}form-input-hint {
   color: $gray-color;
   font-size: $font-size-sm;
   margin-top: $unit-1;
 
-  .has-success &,
-  .is-success + & {
+  .#{$prefix}has-success &,
+  .#{$prefix}is-success + & {
     color: $success-color;
   }
 
-  .has-error &,
-  .is-error + & {
+  .#{$prefix}has-error &,
+  .#{$prefix}is-error + & {
     color: $error-color;
   }
 }
 
 // Form element: Select
-.form-select {
+.#{$prefix}form-select {
   appearance: none;
   border: $border-width solid $border-color-dark;
   border-radius: $border-radius;
@@ -122,7 +122,7 @@ textarea.form-input {
   &[size],
   &[multiple] {
     height: auto;
-    
+
     option {
       padding: $unit-h $unit-1;
     }
@@ -140,13 +140,13 @@ textarea.form-input {
   }
 
   // Select sizes
-  &.select-sm {
+  &.#{$prefix}select-sm {
     font-size: $font-size-sm;
     height: $control-size-sm;
     padding: $control-padding-y-sm ($control-icon-size + $control-padding-x-sm) $control-padding-y-sm $control-padding-x-sm;
   }
 
-  &.select-lg {
+  &.#{$prefix}select-lg {
     font-size: $font-size-lg;
     height: $control-size-lg;
     padding: $control-padding-y-lg ($control-icon-size + $control-padding-x-lg) $control-padding-y-lg $control-padding-x-lg;
@@ -154,11 +154,11 @@ textarea.form-input {
 }
 
 // Form Icons
-.has-icon-left,
-.has-icon-right {
+.#{$prefix}has-icon-left,
+.#{$prefix}has-icon-right {
   position: relative;
 
-  .form-icon {
+  .#{$prefix}form-icon {
     height: $control-icon-size;
     margin: 0 $control-padding-y;
     position: absolute;
@@ -169,35 +169,36 @@ textarea.form-input {
   }
 }
 
-.has-icon-left {
-  .form-icon {
+.#{$prefix}has-icon-left {
+  .#{$prefix}form-icon {
     left: $border-width;
   }
 
-  .form-input {
+  .#{$prefix}form-input {
     padding-left: $control-icon-size + $control-padding-y * 2;
   }
 }
 
-.has-icon-right {
-  .form-icon {
+.#{$prefix}has-icon-right {
+  .#{$prefix}form-icon {
     right: $border-width;
   }
 
-  .form-input {
+  .#{$prefix}form-input {
     padding-right: $control-icon-size + $control-padding-y * 2;
   }
 }
 
 // Form element: Checkbox and Radio
-.form-checkbox,
-.form-radio,
-.form-switch {
+.#{$prefix}form-checkbox,
+.#{$prefix}form-radio,
+.#{$prefix}form-switch {
   display: inline-block;
   line-height: $line-height;
   margin: ($control-size - $control-size-sm) / 2 0;
   min-height: 1.2rem;
-  padding: (($control-size-sm - $line-height) / 2) $control-padding-x (($control-size-sm - $line-height) / 2) ($control-icon-size + $control-padding-x);
+  padding: (($control-size-sm - $line-height) / 2) $control-padding-x (($control-size-sm - $line-height) / 2)
+    ($control-icon-size + $control-padding-x);
   position: relative;
 
   input {
@@ -207,17 +208,18 @@ textarea.form-input {
     overflow: hidden;
     position: absolute;
     width: 1px;
-    &:focus + .form-icon {
+
+    &:focus + .#{$prefix}form-icon {
       @include control-shadow();
       border-color: $primary-color;
     }
-    &:checked + .form-icon {
+    &:checked + .#{$prefix}form-icon {
       background: $primary-color;
       border-color: $primary-color;
     }
   }
 
-  .form-icon {
+  .#{$prefix}form-icon {
     @include control-transition();
     border: $border-width solid $border-color-dark;
     cursor: pointer;
@@ -226,20 +228,20 @@ textarea.form-input {
   }
 
   // Input checkbox, radio and switch sizes
-  &.input-sm {
+  &.#{$prefix}input-sm {
     font-size: $font-size-sm;
     margin: 0;
   }
 
-  &.input-lg {
+  &.#{$prefix}input-lg {
     font-size: $font-size-lg;
     margin: ($control-size-lg - $control-size-sm) / 2 0;
   }
 }
 
-.form-checkbox,
-.form-radio {
-  .form-icon {
+.#{$prefix}form-checkbox,
+.#{$prefix}form-radio {
+  .#{$prefix}form-icon {
     background: $bg-color-light;
     height: $control-icon-size;
     left: 0;
@@ -248,18 +250,19 @@ textarea.form-input {
   }
 
   input {
-    &:active + .form-icon {
+    &:active + .#{$prefix}form-icon {
       background: $bg-color-dark;
     }
   }
 }
-.form-checkbox {
-  .form-icon {
+
+.#{$prefix}form-checkbox {
+  .#{$prefix}form-icon {
     border-radius: $border-radius;
   }
 
   input {
-    &:checked + .form-icon {
+    &:checked + .#{$prefix}form-icon {
       &::before {
         background-clip: padding-box;
         border: $border-width-lg solid $light-color;
@@ -276,9 +279,11 @@ textarea.form-input {
         width: 8px;
       }
     }
-    &:indeterminate + .form-icon {
+
+    &:indeterminate + .#{$prefix}form-icon {
       background: $primary-color;
       border-color: $primary-color;
+
       &::before {
         background: $bg-color-light;
         content: "";
@@ -293,13 +298,14 @@ textarea.form-input {
     }
   }
 }
-.form-radio {
-  .form-icon {
+
+.#{$prefix}form-radio {
+  .#{$prefix}form-icon {
     border-radius: 50%;
   }
 
   input {
-    &:checked + .form-icon {
+    &:checked + .#{$prefix}form-icon {
       &::before {
         background: $bg-color-light;
         border-radius: 50%;
@@ -316,10 +322,10 @@ textarea.form-input {
 }
 
 // Form element: Switch
-.form-switch {
+.#{$prefix}form-switch {
   padding-left: ($unit-8 + $control-padding-x);
 
-  .form-icon {
+  .#{$prefix}form-icon {
     background: $gray-color-light;
     background-clip: padding-box;
     border-radius: $unit-2 + $border-width;
@@ -327,6 +333,7 @@ textarea.form-input {
     left: 0;
     top: ($control-size-sm - $unit-4) / 2 - $border-width;
     width: $unit-8;
+
     &::before {
       @include control-transition();
       background: $bg-color-light;
@@ -356,10 +363,10 @@ textarea.form-input {
 }
 
 // Form element: Input groups
-.input-group {
+.#{$prefix}input-group {
   display: flex;
 
-  .input-group-addon {
+  .#{$prefix}input-group-addon {
     background: $bg-color;
     border: $border-width solid $border-color-dark;
     border-radius: $border-radius;
@@ -367,70 +374,73 @@ textarea.form-input {
     padding: $control-padding-y $control-padding-x;
     white-space: nowrap;
 
-    &.addon-sm {
+    &.#{$prefix}addon-sm {
       font-size: $font-size-sm;
       padding: $control-padding-y-sm $control-padding-x-sm;
     }
 
-    &.addon-lg {
+    &.#{$prefix}addon-lg {
       font-size: $font-size-lg;
       padding: $control-padding-y-lg $control-padding-x-lg;
     }
   }
 
-  .form-input,
-  .form-select {
+  .#{$prefix}form-input,
+  .#{$prefix}form-select {
     flex: 1 1 auto;
   }
 
-  .input-group-btn {
+  .#{$prefix}input-group-btn {
     z-index: $zindex-0;
   }
 
-  .form-input,
-  .form-select,
-  .input-group-addon,
-  .input-group-btn {
+  .#{$prefix}form-input,
+  .#{$prefix}form-select,
+  .#{$prefix}input-group-addon,
+  .#{$prefix}input-group-btn {
     &:first-child:not(:last-child) {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
     }
+
     &:not(:first-child):not(:last-child) {
       border-radius: 0;
       margin-left: -$border-width;
     }
+
     &:last-child:not(:first-child) {
       border-bottom-left-radius: 0;
       border-top-left-radius: 0;
       margin-left: -$border-width;
     }
+
     &:focus {
       z-index: $zindex-0 + 1;
     }
   }
 
-  .form-select {
+  .#{$prefix}form-select {
     width: auto;
   }
 
-  &.input-inline {
+  &.#{$prefix}input-inline {
     display: inline-flex;
   }
 }
 
 // Form validation states
-.form-input,
-.form-select {
-  .has-success &,
-  &.is-success {
+.#{$prefix}form-input,
+.#{$prefix}form-select {
+  .#{$prefix}has-success &,
+  &.#{$prefix}is-success {
     border-color: $success-color;
     &:focus {
       @include control-shadow($success-color);
     }
   }
 
-  .has-error &,
-  &.is-error {
+  .#{$prefix}has-error &,
+  &.#{$prefix}is-error {
     border-color: $error-color;
     &:focus {
       @include control-shadow($error-color);
@@ -438,22 +448,22 @@ textarea.form-input {
   }
 }
 
-.form-checkbox,
-.form-radio,
-.form-switch {
-  .has-error &,
-  &.is-error {
-    .form-icon {
+.#{$prefix}form-checkbox,
+.#{$prefix}form-radio,
+.#{$prefix}form-switch {
+  .#{$prefix}has-error &,
+  &.#{$prefix}is-error {
+    .#{$prefix}form-icon {
       border-color: $error-color;
     }
-    
+
     input {
-      &:checked + .form-icon {
+      &:checked + .#{$prefix}form-icon {
         background: $error-color;
         border-color: $error-color;
       }
 
-      &:focus + .form-icon {
+      &:focus + .#{$prefix}form-icon {
         @include control-shadow($error-color);
         border-color: $error-color;
       }
@@ -462,15 +472,16 @@ textarea.form-input {
 }
 
 // validation based on :placeholder-shown (Edge doesn't support it yet)
-.form-input {
+.#{$prefix}form-input {
   &:not(:placeholder-shown) {
     &:invalid {
       border-color: $error-color;
+
       &:focus {
         @include control-shadow($error-color);
       }
 
-      & + .form-input-hint {
+      & + .#{$prefix}form-input-hint {
         color: $error-color;
       }
     }
@@ -478,17 +489,17 @@ textarea.form-input {
 }
 
 // Form disabled and readonly
-.form-input,
-.form-select {
+.#{$prefix}form-input,
+.#{$prefix}form-select {
   &:disabled,
-  &.disabled {
+  &.#{$prefix}disabled {
     background-color: $bg-color-dark;
     cursor: not-allowed;
     opacity: .5;
   }
 }
 
-.form-input {
+.#{$prefix}form-input {
   &[readonly] {
     background-color: $bg-color;
   }
@@ -496,7 +507,7 @@ textarea.form-input {
 
 input {
   &:disabled,
-  &.disabled {
+  &.#{$prefix}disabled {
     & + .form-icon {
       background: $bg-color-dark;
       cursor: not-allowed;
@@ -505,11 +516,11 @@ input {
   }
 }
 
-.form-switch {
+.#{$prefix}form-switch {
   input {
     &:disabled,
     &.disabled {
-      & + .form-icon::before {
+      & + .#{$prefix}form-icon::before {
         background: $bg-color-light;
       }
     }
@@ -517,10 +528,10 @@ input {
 }
 
 // Form Horizontal
-.form-horizontal {
+.#{$prefix}form-horizontal {
   padding: $layout-spacing 0;
 
-  .form-group {
+  .#{$prefix}form-group {
     display: flex;
     flex-wrap: wrap;
   }

--- a/src/_labels.scss
+++ b/src/_labels.scss
@@ -1,34 +1,34 @@
 // Labels
-.label {
+.#{$prefix}label {
   @include label-base();
   @include label-variant(lighten($body-font-color, 5%), $bg-color-dark);
   display: inline-block;
 
   // Label rounded
-  &.label-rounded {
+  &.#{$prefix}label-rounded {
     border-radius: 5rem;
     padding-left: .4rem;
     padding-right: .4rem; 
   }
 
   // Label colors
-  &.label-primary {
+  &.#{$prefix}label-primary {
     @include label-variant($light-color, $primary-color);
   }
 
-  &.label-secondary {
+  &.#{$prefix}label-secondary {
     @include label-variant($primary-color, $secondary-color);
   }
 
-  &.label-success {
+  &.#{$prefix}label-success {
     @include label-variant($light-color, $success-color);
   }
 
-  &.label-warning {
+  &.#{$prefix}label-warning {
     @include label-variant($light-color, $warning-color);
   }
 
-  &.label-error {
+  &.#{$prefix}label-error {
     @include label-variant($light-color, $error-color);
   }
 }

--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -1,11 +1,11 @@
 // Layout
 .#{$prefix}container {
+  @include clearfix;
   margin-left: auto;
   margin-right: auto;
   padding-left: $layout-spacing;
   padding-right: $layout-spacing;
   width: 100%;
-  @extend .clearfix;
 
   $grid-spacing: ($layout-spacing / ($layout-spacing * 0 + 1)) * $html-font-size;
 

--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -9,23 +9,23 @@
 
   $grid-spacing: ($layout-spacing / ($layout-spacing * 0 + 1)) * $html-font-size;
 
-  &.grid-xl {
+  &.#{$prefix}grid-xl {
     max-width: $grid-spacing * 2 + $size-xl;
   }
 
-  &.grid-lg {
+  &.#{$prefix}grid-lg {
     max-width: $grid-spacing * 2 + $size-lg;
   }
 
-  &.grid-md {
+  &.#{$prefix}grid-md {
     max-width: $grid-spacing * 2 + $size-md;
   }
 
-  &.grid-sm {
+  &.#{$prefix}grid-sm {
     max-width: $grid-spacing * 2 + $size-sm;
   }
 
-  &.grid-xs {
+  &.#{$prefix}grid-xs {
     max-width: $grid-spacing * 2 + $size-xs;
   }
 }

--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -1,5 +1,5 @@
 // Layout
-.container {
+.#{$prefix}container {
   margin-left: auto;
   margin-right: auto;
   padding-left: $layout-spacing;
@@ -31,394 +31,484 @@
 }
 
 // Responsive breakpoint system
-.show-xs,
-.show-sm,
-.show-md,
-.show-lg,
-.show-xl {
+.#{$prefix}show-xs,
+.#{$prefix}show-sm,
+.#{$prefix}show-md,
+.#{$prefix}show-lg,
+.#{$prefix}show-xl {
   display: none !important;
 }
 
 // Responsive grid system
-.columns {
+.#{$prefix}columns {
   display: flex;
   flex-wrap: wrap;
   margin-left: -$layout-spacing;
   margin-right: -$layout-spacing;
 
-  &.col-gapless {
+  &.#{$prefix}col-gapless {
     margin-left: 0;
     margin-right: 0;
 
-    & > .column {
+    & > .#{$prefix}column {
       padding-left: 0;
       padding-right: 0;
     }
   }
-  &.col-oneline {
+
+  &.#{$prefix}col-oneline {
     flex-wrap: nowrap;
     overflow-x: auto;
   }
 }
-.column {
+
+.#{$prefix}column {
   flex: 1;
   max-width: 100%;
   padding-left: $layout-spacing;
   padding-right: $layout-spacing;
 
-  &.col-12,
-  &.col-11,
-  &.col-10,
-  &.col-9,
-  &.col-8,
-  &.col-7,
-  &.col-6,
-  &.col-5,
-  &.col-4,
-  &.col-3,
-  &.col-2,
-  &.col-1 {
+  &.#{$prefix}col-12,
+  &.#{$prefix}col-11,
+  &.#{$prefix}col-10,
+  &.#{$prefix}col-9,
+  &.#{$prefix}col-8,
+  &.#{$prefix}col-7,
+  &.#{$prefix}col-6,
+  &.#{$prefix}col-5,
+  &.#{$prefix}col-4,
+  &.#{$prefix}col-3,
+  &.#{$prefix}col-2,
+  &.#{$prefix}col-1 {
     flex: none;
   }
 }
-.col-12 {
+
+.#{$prefix}col-12 {
   width: 100%;
 }
-.col-11 {
+
+.#{$prefix}col-11 {
   width: 91.66666667%;
 }
-.col-10 {
+
+.#{$prefix}col-10 {
   width: 83.33333333%;
 }
-.col-9 {
+
+.#{$prefix}col-9 {
   width: 75%;
 }
-.col-8 {
+
+.#{$prefix}col-8 {
   width: 66.66666667%;
 }
-.col-7 {
+
+.#{$prefix}col-7 {
   width: 58.33333333%;
 }
-.col-6 {
+
+.#{$prefix}col-6 {
   width: 50%;
 }
-.col-5 {
+
+.#{$prefix}col-5 {
   width: 41.66666667%;
 }
-.col-4 {
+
+.#{$prefix}col-4 {
   width: 33.33333333%;
 }
-.col-3 {
+
+.#{$prefix}col-3 {
   width: 25%;
 }
-.col-2 {
+
+.#{$prefix}col-2 {
   width: 16.66666667%;
 }
-.col-1 {
+
+.#{$prefix}col-1 {
   width: 8.33333333%;
 }
-.col-auto {
+
+.#{$prefix}col-auto {
   flex: 0 0 auto;
   max-width: none;
   width: auto;
 }
-.col-mx-auto {
+
+.#{$prefix}col-mx-auto {
   margin-left: auto;
   margin-right: auto;
 }
-.col-ml-auto {
+
+.#{$prefix}col-ml-auto {
   margin-left: auto;
 }
-.col-mr-auto {
+
+.#{$prefix}col-mr-auto {
   margin-right: auto;
 }
+
 @media (max-width: $size-xl) {
-  .col-xl-12,
-  .col-xl-11,
-  .col-xl-10,
-  .col-xl-9,
-  .col-xl-8,
-  .col-xl-7,
-  .col-xl-6,
-  .col-xl-5,
-  .col-xl-4,
-  .col-xl-3,
-  .col-xl-2,
-  .col-xl-1 {
+  .#{$prefix}col-xl-12,
+  .#{$prefix}col-xl-11,
+  .#{$prefix}col-xl-10,
+  .#{$prefix}col-xl-9,
+  .#{$prefix}col-xl-8,
+  .#{$prefix}col-xl-7,
+  .#{$prefix}col-xl-6,
+  .#{$prefix}col-xl-5,
+  .#{$prefix}col-xl-4,
+  .#{$prefix}col-xl-3,
+  .#{$prefix}col-xl-2,
+  .#{$prefix}col-xl-1 {
     flex: none;
   }
-  .col-xl-12 {
+
+  .#{$prefix}col-xl-12 {
     width: 100%;
   }
-  .col-xl-11 {
+
+  .#{$prefix}col-xl-11 {
     width: 91.66666667%;
   }
-  .col-xl-10 {
+
+  .#{$prefix}col-xl-10 {
     width: 83.33333333%;
   }
-  .col-xl-9 {
+
+  .#{$prefix}col-xl-9 {
     width: 75%;
   }
-  .col-xl-8 {
+
+  .#{$prefix}col-xl-8 {
     width: 66.66666667%;
   }
-  .col-xl-7 {
+
+  .#{$prefix}col-xl-7 {
     width: 58.33333333%;
   }
-  .col-xl-6 {
+
+  .#{$prefix}col-xl-6 {
     width: 50%;
   }
-  .col-xl-5 {
+
+  .#{$prefix}col-xl-5 {
     width: 41.66666667%;
   }
-  .col-xl-4 {
+
+  .#{$prefix}col-xl-4 {
     width: 33.33333333%;
   }
-  .col-xl-3 {
+
+  .#{$prefix}col-xl-3 {
     width: 25%;
   }
-  .col-xl-2 {
+
+  .#{$prefix}col-xl-2 {
     width: 16.66666667%;
   }
-  .col-xl-1 {
+
+  .#{$prefix}col-xl-1 {
     width: 8.33333333%;
   }
-  .hide-xl {
+
+  .#{$prefix}hide-xl {
     display: none !important;
   }
-  .show-xl {
+
+  .#{$prefix}show-xl {
     display: block !important;
   }
 }
+
 @media (max-width: $size-lg) {
-  .col-lg-12,
-  .col-lg-11,
-  .col-lg-10,
-  .col-lg-9,
-  .col-lg-8,
-  .col-lg-7,
-  .col-lg-6,
-  .col-lg-5,
-  .col-lg-4,
-  .col-lg-3,
-  .col-lg-2,
-  .col-lg-1 {
+  .#{$prefix}col-lg-12,
+  .#{$prefix}col-lg-11,
+  .#{$prefix}col-lg-10,
+  .#{$prefix}col-lg-9,
+  .#{$prefix}col-lg-8,
+  .#{$prefix}col-lg-7,
+  .#{$prefix}col-lg-6,
+  .#{$prefix}col-lg-5,
+  .#{$prefix}col-lg-4,
+  .#{$prefix}col-lg-3,
+  .#{$prefix}col-lg-2,
+  .#{$prefix}col-lg-1 {
     flex: none;
   }
-  .col-lg-12 {
+
+  .#{$prefix}col-lg-12 {
     width: 100%;
   }
-  .col-lg-11 {
+
+  .#{$prefix}col-lg-11 {
     width: 91.66666667%;
   }
-  .col-lg-10 {
+
+  .#{$prefix}col-lg-10 {
     width: 83.33333333%;
   }
-  .col-lg-9 {
+
+  .#{$prefix}col-lg-9 {
     width: 75%;
   }
-  .col-lg-8 {
+
+  .#{$prefix}col-lg-8 {
     width: 66.66666667%;
   }
-  .col-lg-7 {
+
+  .#{$prefix}col-lg-7 {
     width: 58.33333333%;
   }
-  .col-lg-6 {
+
+  .#{$prefix}col-lg-6 {
     width: 50%;
   }
-  .col-lg-5 {
+
+  .#{$prefix}col-lg-5 {
     width: 41.66666667%;
   }
-  .col-lg-4 {
+
+  .#{$prefix}col-lg-4 {
     width: 33.33333333%;
   }
-  .col-lg-3 {
+
+  .#{$prefix}col-lg-3 {
     width: 25%;
   }
-  .col-lg-2 {
+
+  .#{$prefix}col-lg-2 {
     width: 16.66666667%;
   }
-  .col-lg-1 {
+
+  .#{$prefix}col-lg-1 {
     width: 8.33333333%;
   }
-  .hide-lg {
+
+  .#{$prefix}hide-lg {
     display: none !important;
   }
-  .show-lg {
+
+  .#{$prefix}show-lg {
     display: block !important;
   }
 }
 @media (max-width: $size-md) {
-  .col-md-12,
-  .col-md-11,
-  .col-md-10,
-  .col-md-9,
-  .col-md-8,
-  .col-md-7,
-  .col-md-6,
-  .col-md-5,
-  .col-md-4,
-  .col-md-3,
-  .col-md-2,
-  .col-md-1 {
+  .#{$prefix}col-md-12,
+  .#{$prefix}col-md-11,
+  .#{$prefix}col-md-10,
+  .#{$prefix}col-md-9,
+  .#{$prefix}col-md-8,
+  .#{$prefix}col-md-7,
+  .#{$prefix}col-md-6,
+  .#{$prefix}col-md-5,
+  .#{$prefix}col-md-4,
+  .#{$prefix}col-md-3,
+  .#{$prefix}col-md-2,
+  .#{$prefix}col-md-1 {
     flex: none;
   }
-  .col-md-12 {
+
+  .#{$prefix}col-md-12 {
     width: 100%;
   }
-  .col-md-11 {
+
+  .#{$prefix}col-md-11 {
     width: 91.66666667%;
   }
-  .col-md-10 {
+
+  .#{$prefix}col-md-10 {
     width: 83.33333333%;
   }
-  .col-md-9 {
+
+  .#{$prefix}col-md-9 {
     width: 75%;
   }
-  .col-md-8 {
+
+  .#{$prefix}col-md-8 {
     width: 66.66666667%;
   }
-  .col-md-7 {
+
+  .#{$prefix}col-md-7 {
     width: 58.33333333%;
   }
-  .col-md-6 {
+
+  .#{$prefix}col-md-6 {
     width: 50%;
   }
-  .col-md-5 {
+
+  .#{$prefix}col-md-5 {
     width: 41.66666667%;
   }
-  .col-md-4 {
+
+  .#{$prefix}col-md-4 {
     width: 33.33333333%;
   }
-  .col-md-3 {
+
+  .#{$prefix}col-md-3 {
     width: 25%;
   }
-  .col-md-2 {
+
+  .#{$prefix}col-md-2 {
     width: 16.66666667%;
   }
-  .col-md-1 {
+
+  .#{$prefix}col-md-1 {
     width: 8.33333333%;
   }
-  .hide-md {
+
+  .#{$prefix}hide-md {
     display: none !important;
   }
-  .show-md {
+
+  .#{$prefix}show-md {
     display: block !important;
   }
 }
 @media (max-width: $size-sm) {
-  .col-sm-12,
-  .col-sm-11,
-  .col-sm-10,
-  .col-sm-9,
-  .col-sm-8,
-  .col-sm-7,
-  .col-sm-6,
-  .col-sm-5,
-  .col-sm-4,
-  .col-sm-3,
-  .col-sm-2,
-  .col-sm-1 {
+  .#{$prefix}col-sm-12,
+  .#{$prefix}col-sm-11,
+  .#{$prefix}col-sm-10,
+  .#{$prefix}col-sm-9,
+  .#{$prefix}col-sm-8,
+  .#{$prefix}col-sm-7,
+  .#{$prefix}col-sm-6,
+  .#{$prefix}col-sm-5,
+  .#{$prefix}col-sm-4,
+  .#{$prefix}col-sm-3,
+  .#{$prefix}col-sm-2,
+  .#{$prefix}col-sm-1 {
     flex: none;
   }
-  .col-sm-12 {
+
+  .#{$prefix}col-sm-12 {
     width: 100%;
   }
-  .col-sm-11 {
+
+  .#{$prefix}col-sm-11 {
     width: 91.66666667%;
   }
-  .col-sm-10 {
+  .#{$prefix}col-sm-10 {
     width: 83.33333333%;
   }
-  .col-sm-9 {
+
+  .#{$prefix}col-sm-9 {
     width: 75%;
   }
-  .col-sm-8 {
+
+  .#{$prefix}col-sm-8 {
     width: 66.66666667%;
   }
-  .col-sm-7 {
+
+  .#{$prefix}col-sm-7 {
     width: 58.33333333%;
   }
-  .col-sm-6 {
+
+  .#{$prefix}col-sm-6 {
     width: 50%;
   }
-  .col-sm-5 {
+
+  .#{$prefix}col-sm-5 {
     width: 41.66666667%;
   }
-  .col-sm-4 {
+
+  .#{$prefix}col-sm-4 {
     width: 33.33333333%;
   }
-  .col-sm-3 {
+
+  .#{$prefix}col-sm-3 {
     width: 25%;
   }
-  .col-sm-2 {
+
+  .#{$prefix}col-sm-2 {
     width: 16.66666667%;
   }
-  .col-sm-1 {
+
+  .#{$prefix}col-sm-1 {
     width: 8.33333333%;
   }
-  .hide-sm {
+
+  .#{$prefix}hide-sm {
     display: none !important;
   }
-  .show-sm {
+
+  .#{$prefix}show-sm {
     display: block !important;
   }
 }
+
 @media (max-width: $size-xs) {
-  .col-xs-12,
-  .col-xs-11,
-  .col-xs-10,
-  .col-xs-9,
-  .col-xs-8,
-  .col-xs-7,
-  .col-xs-6,
-  .col-xs-5,
-  .col-xs-4,
-  .col-xs-3,
-  .col-xs-2,
-  .col-xs-1 {
+  .#{$prefix}col-xs-12,
+  .#{$prefix}col-xs-11,
+  .#{$prefix}col-xs-10,
+  .#{$prefix}col-xs-9,
+  .#{$prefix}col-xs-8,
+  .#{$prefix}col-xs-7,
+  .#{$prefix}col-xs-6,
+  .#{$prefix}col-xs-5,
+  .#{$prefix}col-xs-4,
+  .#{$prefix}col-xs-3,
+  .#{$prefix}col-xs-2,
+  .#{$prefix}col-xs-1 {
     flex: none;
   }
-  .col-xs-12 {
+
+  .#{$prefix}col-xs-12 {
     width: 100%;
   }
-  .col-xs-11 {
+
+  .#{$prefix}col-xs-11 {
     width: 91.66666667%;
   }
-  .col-xs-10 {
+
+  .#{$prefix}col-xs-10 {
     width: 83.33333333%;
   }
-  .col-xs-9 {
+
+  .#{$prefix}col-xs-9 {
     width: 75%;
   }
-  .col-xs-8 {
+
+  .#{$prefix}col-xs-8 {
     width: 66.66666667%;
   }
-  .col-xs-7 {
+
+  .#{$prefix}col-xs-7 {
     width: 58.33333333%;
   }
-  .col-xs-6 {
+
+  .#{$prefix}col-xs-6 {
     width: 50%;
   }
-  .col-xs-5 {
+
+  .#{$prefix}col-xs-5 {
     width: 41.66666667%;
   }
-  .col-xs-4 {
+
+  .#{$prefix}col-xs-4 {
     width: 33.33333333%;
   }
-  .col-xs-3 {
+
+  .#{$prefix}col-xs-3 {
     width: 25%;
   }
-  .col-xs-2 {
+
+  .#{$prefix}col-xs-2 {
     width: 16.66666667%;
   }
-  .col-xs-1 {
+
+  .#{$prefix}col-xs-1 {
     width: 8.33333333%;
   }
-  .hide-xs {
+
+  .#{$prefix}hide-xs {
     display: none !important;
   }
-  .show-xs {
+
+  .#{$prefix}show-xs {
     display: block !important;
   }
 }

--- a/src/_media.scss
+++ b/src/_media.scss
@@ -1,6 +1,6 @@
 // Media
 // Image responsive
-.img-responsive {
+.#{$prefix}img-responsive {
   display: block;
   height: auto;
   max-width: 100%;
@@ -8,16 +8,16 @@
 
 // object-fit support is coming to Microsoft Edge
 // https://developer.microsoft.com/en-us/microsoft-edge/platform/status/objectfitandobjectposition/
-.img-fit-cover {
+.#{$prefix}img-fit-cover {
   object-fit: cover;
 }
 
-.img-fit-contain {
+.#{$prefix}img-fit-contain {
   object-fit: contain;
 }
 
 // Video responsive
-.video-responsive {
+.#{$prefix}video-responsive {
   display: block;
   overflow: hidden;
   padding: 0;
@@ -43,7 +43,7 @@
   }
 }
 
-video.video-responsive {
+video.#{$prefix}video-responsive {
   height: auto;
   max-width: 100%;
 
@@ -52,23 +52,23 @@ video.video-responsive {
   }
 }
 
-.video-responsive-4-3 {
+.#{$prefix}video-responsive-4-3 {
   &::before {
     padding-bottom: 75%; // Ratio 4:3
   }
 }
 
-.video-responsive-1-1 {
+.#{$prefix}video-responsive-1-1 {
   &::before {
     padding-bottom: 100%; // Ratio 1:1
   }
 }
 
 // Figure
-.figure {
+.#{$prefix}figure {
   margin: 0 0 $layout-spacing 0;
 
-  .figure-caption {
+  .#{$prefix}figure-caption {
     color: $gray-color-dark;
     margin-top: $layout-spacing;
   }

--- a/src/_menus.scss
+++ b/src/_menus.scss
@@ -1,5 +1,5 @@
 // Menus
-.menu {
+.#{$prefix}menu {
   @include shadow-variant(.05rem);
   background: $bg-color-light;
   border-radius: $border-radius;
@@ -10,12 +10,12 @@
   transform: translateY($layout-spacing-sm);
   z-index: $zindex-3;
 
-  &.menu-nav {
+  &.#{$prefix}menu-nav {
     background: transparent;
     box-shadow: none;
   }
 
-  .menu-item {
+  .#{$prefix}menu-item {
     margin-top: 0;
     padding: 0 $unit-2;
     text-decoration: none;
@@ -34,28 +34,28 @@
         color: $primary-color;
       }
       &:active,
-      &.active {
+      &.#{$prefix}active {
         background: $secondary-color;
         color: $primary-color;
       }
     }
 
-    .form-checkbox,
-    .form-radio,
-    .form-switch {
+    .#{$prefix}form-checkbox,
+    .#{$prefix}form-radio,
+    .#{$prefix}form-switch {
       margin: $unit-h 0;
     }
 
-    & + .menu-item {
+    & + .#{$prefix}menu-item {
       margin-top: $unit-1;
     }
   }
 
-  .menu-badge {
+  .#{$prefix}menu-badge {
     float: right;
     padding: $unit-1 0;
 
-    .btn {
+    .#{$prefix}btn {
       margin-top: -$unit-h;
     }
   }

--- a/src/_meters.scss
+++ b/src/_meters.scss
@@ -1,6 +1,6 @@
 // Meters
 // Credit: https://css-tricks.com/html5-meter-element/
-.meter {
+.#{$prefix}meter {
   appearance: none;
   background: $bg-color;
   border: 0;

--- a/src/_modals.scss
+++ b/src/_modals.scss
@@ -1,5 +1,5 @@
 // Modals
-.modal {
+.#{$prefix}modal {
   align-items: center;
   bottom: 0;
   display: none;
@@ -13,14 +13,14 @@
   top: 0;
 
   &:target,
-  &.active {
+  &.#{$prefix}active {
     display: flex;
     opacity: 1;
     z-index: $zindex-4;
 
-    .modal-overlay {
-      background: rgba($bg-color, .75);
+    .#{$prefix}modal-overlay {
       bottom: 0;
+      background: rgba($bg-color, .75);
       cursor: default;
       display: block;
       left: 0;
@@ -29,35 +29,34 @@
       top: 0;
     }
 
-    .modal-container {
-      animation: slide-down .2s ease 1;
+    .#{$prefix}modal-container {
+      animation: #{$prefix}slide-down 0.2s ease 1;
       max-width: $control-width-md;
       width: 100%;
       z-index: $zindex-0;
     }
   }
 
-  &.modal-sm {
+  &.#{$prefix}modal-sm {
     .modal-container {
       max-width: $control-width-sm;
       padding: 0 $unit-2;
     }
   }
 
-  &.modal-lg {
-    .modal-overlay {
+  &.#{$prefix}modal-lg {
+    .#{$prefix}modal-overlay {
       background: $bg-color-light;
     }
 
-    .modal-container {
+    .#{$prefix}modal-container {
       box-shadow: none;
       max-width: $control-width-lg;
     }
   }
 }
 
-.modal-container {
-  @include shadow-variant(.2rem);
+.#{$prefix}modal-container {
   background: $bg-color-light;
   border-radius: $border-radius;
   display: block;
@@ -67,6 +66,7 @@
     padding: $unit-4;
   }
 
+  @include shadow-variant(.2rem);
   .modal-body {
     max-height: 50vh;
     overflow-y: auto;

--- a/src/_navbar.scss
+++ b/src/_navbar.scss
@@ -1,11 +1,11 @@
 // Navbar
-.navbar {
+.#{$prefix}navbar {
   align-items: stretch;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
 
-  .navbar-section {
+  .#{$prefix}navbar-section {
     align-items: center;
     display: flex;
     flex: 1 0 0;
@@ -15,13 +15,13 @@
     }
   }
 
-  .navbar-center {
+  .#{$prefix}navbar-center {
     align-items: center;
     display: flex;
     flex: 0 0 auto;
   }
 
-  .navbar-brand {
+  .#{$prefix}navbar-brand {
     font-size: $font-size-lg;
     font-weight: 500;
     text-decoration: none;

--- a/src/_navs.scss
+++ b/src/_navs.scss
@@ -1,11 +1,11 @@
 // Navs
-.nav {
+.#{$prefix}nav {
   display: flex;
   flex-direction: column;
   list-style: none;
   margin: $unit-1 0;
 
-  .nav-item {
+  .#{$prefix}nav-item {
     a {
       color: $gray-color-dark;
       padding: $unit-1 $unit-2;
@@ -15,7 +15,8 @@
         color: $primary-color;
       }
     }
-    &.active {
+
+    &.#{$prefix}active {
       & > a {
         color: darken($gray-color-dark, 10%);
         font-weight: bold;
@@ -27,7 +28,7 @@
     }
   }
 
-  & .nav {
+  & .#{$prefix}nav {
     margin-bottom: $unit-2;
     margin-left: $unit-4;
   }

--- a/src/_off-canvas.scss
+++ b/src/_off-canvas.scss
@@ -1,19 +1,20 @@
 // Off canvas menus
 $off-canvas-breakpoint: $size-lg !default;
 
-.off-canvas {
+.#{$prefix}off-canvas {
   display: flex;
   flex-flow: nowrap;
   height: 100%;
   position: relative;
   width: 100%;
 
-  .off-canvas-toggle {
+  .#{$prefix}off-canvas-toggle {
     display: block;
     position: absolute;
     top: $layout-spacing;
     transition: none;
     z-index: $zindex-0;
+
     @if $rtl == true {
       right: $layout-spacing;
     } @else {
@@ -21,7 +22,7 @@ $off-canvas-breakpoint: $size-lg !default;
     }
   }
 
-  .off-canvas-sidebar {
+  .#{$prefix}off-canvas-sidebar {
     background: $bg-color;
     bottom: 0;
     min-width: 10rem;
@@ -30,6 +31,7 @@ $off-canvas-breakpoint: $size-lg !default;
     top: 0;
     transition: transform .25s ease;
     z-index: $zindex-2;
+
     @if $rtl == true {
       right: 0;
       transform: translateX(100%);
@@ -39,18 +41,18 @@ $off-canvas-breakpoint: $size-lg !default;
     }
   }
 
-  .off-canvas-content {
+  .#{$prefix}off-canvas-content {
     flex: 1 1 auto;
     height: 100%;
     padding: $layout-spacing $layout-spacing $layout-spacing 4rem;
   }
 
-  .off-canvas-overlay {
-    background: rgba($dark-color, .1);
+  .#{$prefix}off-canvas-overlay {
     border-color: transparent;
     border-radius: 0;
     bottom: 0;
     display: none;
+    background: rgba($dark-color, .1);
     height: 100%;
     left: 0;
     position: fixed;
@@ -59,14 +61,14 @@ $off-canvas-breakpoint: $size-lg !default;
     width: 100%;
   }
 
-  .off-canvas-sidebar {
+  .#{$prefix}off-canvas-sidebar {
     &:target,
-    &.active {
+    &.#{$prefix}active {
       transform: translateX(0);
     }
 
     &:target ~ .off-canvas-overlay,
-    &.active ~ .off-canvas-overlay {
+    &.#{$prefix}active ~ .#{$prefix}off-canvas-overlay {
       display: block;
       z-index: $zindex-1;
     }
@@ -75,13 +77,13 @@ $off-canvas-breakpoint: $size-lg !default;
 
 // Responsive layout
 @media (min-width: $off-canvas-breakpoint) {
-  .off-canvas {
-    &.off-canvas-sidebar-show {
-      .off-canvas-toggle {
+  .#{$prefix}off-canvas {
+    &.#{$prefix}off-canvas-sidebar-show {
+      .#{$prefix}off-canvas-toggle {
         display: none;
       }
-  
-      .off-canvas-sidebar {
+
+      .#{$prefix}off-canvas-sidebar {
         flex: 0 0 auto;
         position: relative;
         transform: none;

--- a/src/_pagination.scss
+++ b/src/_pagination.scss
@@ -1,11 +1,11 @@
 // Pagination
-.pagination {
+.#{$prefix}pagination {
   display: flex;
   list-style: none;
   margin: $unit-1 0;
   padding: $unit-1 0;
 
-  .page-item {
+  .#{$prefix}page-item {
     margin: $unit-1 $unit-o;
 
     span {
@@ -25,7 +25,7 @@
       }
     }
 
-    &.disabled {
+    &.#{$prefix}disabled {
       a {
         cursor: default;
         opacity: .5;
@@ -33,27 +33,27 @@
       }
     }
 
-    &.active {
+    &.#{$prefix}active {
       a {
         background: $primary-color;
         color: $light-color;
       }
     }
 
-    &.page-prev,
-    &.page-next {
+    &.#{$prefix}page-prev,
+    &.#{$prefix}page-next {
       flex: 1 0 50%;
     }
 
-    &.page-next {
+    &.#{$prefix}page-next {
       text-align: right;
     }
 
-    .page-item-title {
+    .#{$prefix}page-item-title {
       margin: 0;
     }
 
-    .page-item-subtitle {
+    .#{$prefix}page-item-subtitle {
       margin: 0;
       opacity: .5;
     }

--- a/src/_panels.scss
+++ b/src/_panels.scss
@@ -1,21 +1,21 @@
 // Panels
-.panel {
+.#{$prefix}panel {
   border: $border-width solid $border-color;
   border-radius: $border-radius;
   display: flex;
   flex-direction: column;
 
-  .panel-header,
-  .panel-footer {
+  .#{$prefix}panel-header,
+  .#{$prefix}panel-footer {
     flex: 0 0 auto;
     padding: $layout-spacing-lg;
   }
 
-  .panel-nav {
+  .#{$prefix}panel-nav {
     flex: 0 0 auto;
   }
 
-  .panel-body {
+  .#{$prefix}panel-body {
     flex: 1 1 auto;
     overflow-y: auto;
     padding: 0 $layout-spacing-lg;

--- a/src/_parallax.scss
+++ b/src/_parallax.scss
@@ -15,13 +15,13 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
   z-index: $zindex-1;
 }
 
-.parallax {
+.#{$prefix}parallax {
   display: block;
   height: auto;
   position: relative;
   width: auto;
 
-  .parallax-content {
+  .#{$prefix}parallax-content {
     @include shadow-variant(1rem);
     height: auto;
     transform: perspective($parallax-perspective);
@@ -40,7 +40,7 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
     }
   }
 
-  .parallax-front {
+  .#{$prefix}parallax-front {
     align-items: center;
     color: $light-color;
     display: flex;
@@ -57,32 +57,32 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
     z-index: $zindex-0;
   }
 
-  .parallax-top-left {
+  .#{$prefix}parallax-top-left {
     @include parallax-dir();
     left: 0;
     top: 0;
 
-    &:focus ~ .parallax-content,
-    &:hover ~ .parallax-content {
+    &:focus ~ .#{$prefix}parallax-content,
+    &:hover ~ .#{$prefix}parallax-content {
       transform: perspective($parallax-perspective) rotateX($parallax-deg) rotateY(-$parallax-deg);
 
       &::before {
         background: linear-gradient(135deg, $parallax-fade-color 0%, transparent 50%);
       }
 
-      .parallax-front {
+      .#{$prefix}parallax-front {
         transform: translate3d($parallax-offset, $parallax-offset, $parallax-offset-z) scale($parallax-scale);
       }
     }
   }
 
-  .parallax-top-right {
+  .#{$prefix}parallax-top-right {
     @include parallax-dir();
     right: 0;
     top: 0;
 
-    &:focus ~ .parallax-content,
-    &:hover ~ .parallax-content {
+    &:focus ~ .#{$prefix}parallax-content,
+    &:hover ~ .#{$prefix}parallax-content {
       transform: perspective($parallax-perspective) rotateX($parallax-deg) rotateY($parallax-deg);
 
       &::before {
@@ -95,13 +95,13 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
     }
   }
 
-  .parallax-bottom-left {
+  .#{$prefix}parallax-bottom-left {
     @include parallax-dir();
     bottom: 0;
     left: 0;
 
-    &:focus ~ .parallax-content,
-    &:hover ~ .parallax-content {
+    &:focus ~ .#{$prefix}parallax-content,
+    &:hover ~ .#{$prefix}parallax-content {
       transform: perspective($parallax-perspective) rotateX(-$parallax-deg) rotateY(-$parallax-deg);
 
       &::before {
@@ -114,20 +114,20 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
     }
   }
 
-  .parallax-bottom-right {
+  .#{$prefix}parallax-bottom-right {
     @include parallax-dir();
     bottom: 0;
     right: 0;
 
-    &:focus ~ .parallax-content,
-    &:hover ~ .parallax-content {
+    &:focus ~ .#{$prefix}parallax-content,
+    &:hover ~ .#{$prefix}parallax-content {
       transform: perspective($parallax-perspective) rotateX(-$parallax-deg) rotateY($parallax-deg);
 
       &::before {
         background: linear-gradient(-45deg, $parallax-fade-color 0%, transparent 50%);
       }
 
-      .parallax-front {
+      .#{$prefix}parallax-front {
         transform: translate3d(-$parallax-offset, -$parallax-offset, $parallax-offset-z) scale($parallax-scale);
       }
     }

--- a/src/_popovers.scss
+++ b/src/_popovers.scss
@@ -1,9 +1,9 @@
 // Popovers
-.popover {
+.#{$prefix}popover {
   display: inline-block;
   position: relative;
 
-  .popover-container {
+  .#{$prefix}popover-container {
     left: 50%;
     opacity: 0;
     padding: $layout-spacing;
@@ -15,55 +15,55 @@
     z-index: $zindex-3;
   }
 
-  *:focus + .popover-container,
-  &:hover .popover-container,
-  .popover-container:hover {
+  *:focus + .#{$prefix}popover-container,
+  &:hover .#{$prefix}popover-container,
+  .#{$prefix}popover-container:hover {
     display: block;
     opacity: 1;
     transform: translate(-50%, -100%) scale(1);
   }
 
-  &.popover-right {
-    .popover-container {
+  &.#{$prefix}popover-right {
+    .#{$prefix}popover-container {
       left: 100%;
       top: 50%;
     }
 
-    :focus + .popover-container,
-    &:hover .popover-container,
-    .popover-container:hover {
+    :focus + .#{$prefix}popover-container,
+    &:hover .#{$prefix}popover-container,
+    .#{$prefix}popover-container:hover {
       transform: translate(0, -50%) scale(1);
     }
   }
 
-  &.popover-bottom {
-    .popover-container {
+  &.#{$prefix}popover-bottom {
+    .#{$prefix}popover-container {
       left: 50%;
       top: 100%;
     }
 
-    :focus + .popover-container,
-    &:hover .popover-container,
-    .popover-container:hover {
+    :focus + .#{$prefix}popover-container,
+    &:hover .#{$prefix}popover-container,
+    .#{$prefix}popover-container:hover {
       transform: translate(-50%, 0) scale(1);
     }
   }
 
-  &.popover-left {
-    .popover-container {
+  &.#{$prefix}popover-left {
+    .#{$prefix}popover-container {
       left: 0;
       top: 50%;
     }
 
-    :focus + .popover-container,
-    &:hover .popover-container,
-    .popover-container:hover {
+    :focus + .#{$prefix}popover-container,
+    &:hover .#{$prefix}popover-container,
+    .#{$prefix}popover-container:hover {
       transform: translate(-100%, -50%) scale(1);
     }
   }
 
-  .card {
-    @include shadow-variant(.2rem);
+  .#{$prefix}card {
+    @include shadow-variant(0.2rem);
     border: 0;
   }
 }

--- a/src/_progress.scss
+++ b/src/_progress.scss
@@ -1,6 +1,6 @@
 // Progress
 // Credit: https://css-tricks.com/html5-progress-element/
-.progress {
+.#{$prefix}progress {
   appearance: none;
   background: $bg-color-dark;
   border: 0;
@@ -35,7 +35,7 @@
   }
 }
 
-@keyframes progress-indeterminate {
+@keyframes #{$prefix}progress-indeterminate {
   0% {
     background-position: 200% 0;
   }

--- a/src/_sliders.scss
+++ b/src/_sliders.scss
@@ -1,6 +1,6 @@
 // Sliders
 // Credit: https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/
-.slider {
+.#{$prefix}slider {
   appearance: none;
   background: transparent;
   display: block;
@@ -29,6 +29,7 @@
     transition: transform .2s ease;
     width: $unit-3;
   }
+
   &::-moz-range-thumb {
     background: $primary-color;
     border: 0;
@@ -37,6 +38,7 @@
     transition: transform .2s ease;
     width: $unit-3;
   }
+
   &::-ms-thumb {
     background: $primary-color;
     border: 0;
@@ -50,24 +52,28 @@
     &::-webkit-slider-thumb {
       transform: scale(1.25);
     }
+
     &::-moz-range-thumb {
       transform: scale(1.25);
     }
+
     &::-ms-thumb {
       transform: scale(1.25);
     }
   }
 
   &:disabled,
-  &.disabled {
+  &.#{$prefix}disabled {
     &::-webkit-slider-thumb {
       background: $gray-color-light;
       transform: scale(1);
     }
+
     &::-moz-range-thumb {
       background: $gray-color-light;
       transform: scale(1);
     }
+
     &::-ms-thumb {
       background: $gray-color-light;
       transform: scale(1);
@@ -81,18 +87,21 @@
     height: $unit-h;
     width: 100%;
   }
+
   &::-moz-range-track {
     background: $bg-color-dark;
     border-radius: $border-radius;
     height: $unit-h;
     width: 100%;
   }
+
   &::-ms-track {
     background: $bg-color-dark;
     border-radius: $border-radius;
     height: $unit-h;
     width: 100%;
   }
+
   &::-ms-fill-lower {
     background: $primary-color;
   }

--- a/src/_steps.scss
+++ b/src/_steps.scss
@@ -1,12 +1,12 @@
 // Steps
-.step {
+.#{$prefix}step {
   display: flex;
   flex-wrap: nowrap;
   list-style: none;
   margin: $unit-1 0;
   width: 100%;
 
-  .step-item {
+  .#{$prefix}step-item {
     flex: 1 1 0;
     margin-top: 0;
     min-height: 1rem;
@@ -45,7 +45,7 @@
       }
     }
 
-    &.active {
+    &.#{$prefix}active {
       a {
         &::before {
           background: $light-color;
@@ -53,13 +53,12 @@
         }
       }
 
-      & ~ .step-item {
+      & ~ .#{$prefix}step-item {
         &::before {
           background: $border-color;
         }
 
         a {
-
           &::before {
             background: $gray-color-light;
           }

--- a/src/_tables.scss
+++ b/src/_tables.scss
@@ -1,15 +1,16 @@
 // Tables
-.table {
+.#{$prefix}table {
   border-collapse: collapse;
   border-spacing: 0;
   width: 100%;
+
   @if $rtl == true {
     text-align: right;
   } @else {
     text-align: left;
   }
 
-  &.table-striped {
+  &.#{$prefix}table-striped {
     tbody {
       tr:nth-of-type(odd) {
         background: $bg-color;
@@ -18,7 +19,7 @@
   }
 
   &,
-  &.table-striped {
+  &.#{$prefix}table-striped {
     tbody {
       tr {
         &.active {
@@ -28,7 +29,7 @@
     }
   }
 
-  &.table-hover {
+  &.#{$prefix}table-hover {
     tbody {
       tr {
         &:hover {
@@ -39,7 +40,7 @@
   }
 
   // Tables with horizontal scrollbar
-  &.table-scroll {
+  &.#{$prefix}table-scroll {
     display: block;
     overflow-x: auto;
     padding-bottom: .75rem;

--- a/src/_tabs.scss
+++ b/src/_tabs.scss
@@ -1,5 +1,5 @@
 // Tabs
-.tab {
+.#{$prefix}tab {
   align-items: center;
   border-bottom: $border-width solid $border-color;
   display: flex;
@@ -7,7 +7,7 @@
   list-style: none;
   margin: $unit-1 0 ($unit-1 - $border-width) 0;
 
-  .tab-item {
+  .#{$prefix}tab-item {
     margin-top: 0;
 
     a {
@@ -28,18 +28,18 @@
       color: $link-color;
     }
 
-    &.tab-action {
+    &.#{$prefix}tab-action {
       flex: 1 0 auto;
       text-align: right;
     }
 
-    .btn-clear {
+    .#{$prefix}btn-clear {
       margin-top: -$unit-1;
     }
   }
 
-  &.tab-block {
-    .tab-item {
+  &.#{$prefix}tab-block {
+    .#{$prefix}tab-item {
       flex: 1 0 0;
       text-align: center;
 
@@ -47,8 +47,8 @@
         margin: 0;
       }
 
-      .badge {
-        &[data-badge]::after {
+      .#{$prefix}badge {
+        &[data-#{$prefix}badge]::after {
           position: absolute;
           right: $unit-h;
           top: $unit-h;
@@ -58,8 +58,8 @@
     }
   }
 
-  &:not(.tab-block) {
-    .badge {
+  &:not(.tab-#{$prefix}block) {
+    .#{$prefix}badge {
       padding-right: 0;
     }
   }

--- a/src/_tiles.scss
+++ b/src/_tiles.scss
@@ -1,36 +1,40 @@
 // Tiles
-.tile {
+.#{$prefix}tile {
   align-content: space-between;
   align-items: flex-start;
   display: flex;
 
-  .tile-icon,
-  .tile-action {
+  .#{$prefix}tile-icon,
+  .#{$prefix}tile-action {
     flex: 0 0 auto;
   }
-  .tile-content {
+
+  .#{$prefix}tile-content {
     flex: 1 1 auto;
+
     &:not(:first-child) {
       padding-left: $unit-2;
     }
+
     &:not(:last-child) {
       padding-right: $unit-2;
     }
   }
-  .tile-title,
-  .tile-subtitle {
+
+  .#{$prefix}tile-title,
+  .#{$prefix}tile-subtitle {
     line-height: $line-height;
   }
 
-  &.tile-centered {
+  &.#{$prefix}tile-centered {
     align-items: center;
 
-    .tile-content {
+    .#{$prefix}tile-content {
       overflow: hidden;
     }
 
-    .tile-title,
-    .tile-subtitle {
+    .#{$prefix}tile-title,
+    .#{$prefix}tile-subtitle {
       @include text-ellipsis();
       margin-bottom: 0;
     }

--- a/src/_timelines.scss
+++ b/src/_timelines.scss
@@ -1,9 +1,10 @@
 // Timelines
-.timeline {
-  .timeline-item {
+.#{$prefix}timeline {
+  .#{$prefix}timeline-item {
     display: flex;
     margin-bottom: $unit-6;
     position: relative;
+
     &::before {
       background: $border-color;
       content: "";
@@ -14,22 +15,23 @@
       width: 2px;
     }
 
-    .timeline-left {
+    .#{$prefix}timeline-left {
       flex: 0 0 auto;
     }
 
-    .timeline-content {
+    .#{$prefix}timeline-content {
       flex: 1 1 auto;
       padding: 2px 0 2px $layout-spacing-lg;
     }
 
-    .timeline-icon {
+    .#{$prefix}timeline-icon {
       border-radius: 50%;
       color: $light-color;
       display: block;
       height: $unit-6;
       text-align: center;
       width: $unit-6;
+
       &::before {
         border: $border-width-lg solid $primary-color;
         border-radius: 50%;
@@ -45,6 +47,7 @@
       &.icon-lg {
         background: $primary-color;
         line-height: $line-height;
+
         &::before {
           content: none;
         }

--- a/src/_toasts.scss
+++ b/src/_toasts.scss
@@ -1,5 +1,5 @@
 // Toasts
-.toast {
+.#{$prefix}toast {
   @include toast-variant($dark-color);
   border: $border-width solid $dark-color;
   border-radius: $border-radius;
@@ -8,26 +8,26 @@
   padding: $layout-spacing;
   width: 100%;
 
-  &.toast-primary {
+  &.#{$prefix}toast-primary {
     @include toast-variant($primary-color);
   }
 
-  &.toast-success {
+  &.#{$prefix}toast-success {
     @include toast-variant($success-color);
   }
 
-  &.toast-warning {
+  &.#{$prefix}toast-warning {
     @include toast-variant($warning-color);
   }
 
-  &.toast-error {
+  &.#{$prefix}toast-error {
     @include toast-variant($error-color);
   }
 
   a {
     color: $light-color;
     text-decoration: underline;
-    
+
     &:focus,
     &:hover,
     &:active,
@@ -36,7 +36,7 @@
     }
   }
 
-  .btn-clear {
+  .#{$prefix}btn-clear {
     margin: 4px -2px 4px 4px;
   }
 }

--- a/src/_tooltips.scss
+++ b/src/_tooltips.scss
@@ -1,6 +1,7 @@
 // Tooltips
-.tooltip {
+.#{$prefix}tooltip {
   position: relative;
+
   &::after {
     background: rgba($dark-color, .9);
     border-radius: $border-radius;
@@ -22,6 +23,7 @@
     white-space: pre;
     z-index: $zindex-3;
   }
+
   &:focus,
   &:hover {
     &::after {
@@ -29,17 +31,19 @@
       transform: translate(-50%, -$unit-1);
     }
   }
+
   &[disabled],
-  &.disabled {
+  &.#{$prefix}disabled {
     pointer-events: auto;
   }
 
-  &.tooltip-right {
+  &.#{$prefix}tooltip-right {
     &::after {
       bottom: 50%;
       left: 100%;
       transform: translate(-$unit-1, 50%);
     }
+
     &:focus,
     &:hover {
       &::after {
@@ -48,12 +52,13 @@
     }
   }
 
-  &.tooltip-bottom {
+  &.#{$prefix}tooltip-bottom {
     &::after {
       bottom: auto;
       top: 100%;
       transform: translate(-50%, -$unit-2);
     }
+
     &:focus,
     &:hover {
       &::after {
@@ -61,8 +66,8 @@
       }
     }
   }
-  
-  &.tooltip-left {
+
+  &.#{$prefix}tooltip-left {
     &::after {
       bottom: 50%;
       left: auto;

--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -12,6 +12,7 @@ h6 {
   margin-bottom: .5em;
   margin-top: 0;
 }
+
 .h1,
 .h2,
 .h3,
@@ -20,28 +21,34 @@ h6 {
 .h6 {
   font-weight: 500;
 }
+
 h1,
-.h1 {
+.#{$prefix}h1 {
   font-size: 2rem;
 }
+
 h2,
-.h2 {
+.#{$prefix}h2 {
   font-size: 1.6rem;
 }
+
 h3,
-.h3 {
+.#{$prefix}h3 {
   font-size: 1.4rem;
 }
+
 h4,
-.h4 {
+.#{$prefix}h4 {
   font-size: 1.2rem;
 }
+
 h5,
-.h5 {
+.#{$prefix}h5 {
   font-size: 1rem;
 }
+
 h6,
-.h6 {
+.#{$prefix}h6 {
   font-size: .8rem;
 }
 

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,5 +1,6 @@
 // Core variables
 $version: "0.5.1";
+$prefix: "" !default;
 
 // Core features
 $rtl: false !default;

--- a/src/icons/_icons-action.scss
+++ b/src/icons/_icons-action.scss
@@ -1,7 +1,6 @@
-
 // Icon resize
-.icon-resize-horiz,
-.icon-resize-vert {
+.#{$icon-prefix}-resize-horiz,
+.#{$icon-prefix}-resize-vert {
   &::before,
   &::after {
     border: $icon-border-width solid currentColor;
@@ -11,26 +10,29 @@
     height: .45em;
     width: .45em;
   }
+
   &::before {
     transform: translate(-50%, -90%) rotate(45deg);
   }
+
   &::after {
     transform: translate(-50%, -10%) rotate(225deg);
   }
 }
 
-.icon-resize-horiz {
+.#{$icon-prefix}-resize-horiz {
   &::before {
     transform: translate(-90%, -50%) rotate(-45deg);
   }
+
   &::after {
     transform: translate(-10%, -50%) rotate(135deg);
   }
 }
 
 // Icon more
-.icon-more-horiz,
-.icon-more-vert {
+.#{$icon-prefix}-more-horiz,
+.#{$icon-prefix}-more-vert {
   &::before {
     background: currentColor;
     box-shadow: -.4em 0, .4em 0;
@@ -41,16 +43,16 @@
   }
 }
 
-.icon-more-vert {
+.#{$icon-prefix}-more-vert {
   &::before {
     box-shadow: 0 -.4em, 0 .4em;
   }
 }
 
 // Icon plus, minus, cross
-.icon-plus,
-.icon-minus,
-.icon-cross {
+.#{$icon-prefix}-plus,
+.#{$icon-prefix}-minus,
+.#{$icon-prefix}-cross {
   &::before {
     background: currentColor;
     content: "";
@@ -59,8 +61,8 @@
   }
 }
 
-.icon-plus,
-.icon-cross {
+.#{$icon-prefix}-plus,
+.#{$icon-prefix}-cross {
   &::after {
     background: currentColor;
     content: "";
@@ -69,13 +71,15 @@
   }
 }
 
-.icon-cross {
+.#{$icon-prefix}-cross {
   &::before {
     width: 100%;
   }
+
   &::after {
     height: 100%;
   }
+
   &::before,
   &::after {
     transform: translate(-50%, -50%) rotate(45deg);
@@ -83,7 +87,7 @@
 }
 
 // Icon check
-.icon-check {
+.#{$icon-prefix}-check {
   &::before {
     border: $icon-border-width solid currentColor;
     border-right: 0;
@@ -96,9 +100,10 @@
 }
 
 // Icon stop
-.icon-stop {
+.#{$icon-prefix}-stop {
   border: $icon-border-width solid currentColor;
   border-radius: 50%;
+
   &::before {
     background: currentColor;
     content: "";
@@ -109,10 +114,11 @@
 }
 
 // Icon shutdown
-.icon-shutdown {
+.#{$icon-prefix}-shutdown {
   border: $icon-border-width solid currentColor;
   border-radius: 50%;
   border-top-color: transparent;
+
   &::before {
     background: currentColor;
     content: "";
@@ -123,7 +129,7 @@
 }
 
 // Icon refresh
-.icon-refresh {
+.#{$icon-prefix}-refresh {
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: 50%;
@@ -132,6 +138,7 @@
     height: 1em;
     width: 1em;
   }
+
   &::after {
     border: .2em solid currentColor;
     border-top-color: transparent;
@@ -145,7 +152,7 @@
 }
 
 // Icon search
-.icon-search {
+.#{$icon-prefix}-search {
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: 50%;
@@ -156,6 +163,7 @@
     transform: translate(0, 0) rotate(45deg);
     width: .75em;
   }
+
   &::after {
     background: currentColor;
     content: "";
@@ -168,7 +176,7 @@
 }
 
 // Icon edit
-.icon-edit {
+.#{$icon-prefix}-edit {
   &::before {
     border: $icon-border-width solid currentColor;
     content: "";
@@ -176,6 +184,7 @@
     transform: translate(-40%, -60%) rotate(-45deg);
     width: .85em;
   }
+
   &::after {
     border: .15em solid currentColor;
     border-top-color: transparent;
@@ -190,7 +199,7 @@
 }
 
 // Icon delete
-.icon-delete {
+.#{$icon-prefix}-delete {
   &::before {
     border: $icon-border-width solid currentColor;
     border-bottom-left-radius: $border-radius;
@@ -201,6 +210,7 @@
     top: 60%;
     width: .75em;
   }
+
   &::after {
     background: currentColor;
     box-shadow: -.25em .2em, .25em .2em;
@@ -212,11 +222,12 @@
 }
 
 // Icon share
-.icon-share {
+.#{$icon-prefix}-share {
   border: $icon-border-width solid currentColor;
   border-radius: $border-radius;
   border-right: 0;
   border-top: 0;
+
   &::before {
     border: $icon-border-width solid currentColor;
     border-left: 0;
@@ -228,6 +239,7 @@
     transform: translate(-125%, -50%) rotate(-45deg);
     width: .4em;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
@@ -240,7 +252,7 @@
 }
 
 // Icon flag
-.icon-flag {
+.#{$icon-prefix}-flag {
   &::before {
     background: currentColor;
     content: "";
@@ -248,6 +260,7 @@
     left: 15%;
     width: $icon-border-width;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-bottom-right-radius: $border-radius;
@@ -262,7 +275,7 @@
 }
 
 // Icon bookmark
-.icon-bookmark {
+.#{$icon-prefix}-bookmark {
   &::before {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
@@ -272,6 +285,7 @@
     height: .9em;
     width: .8em;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
@@ -285,9 +299,10 @@
 }
 
 // Icon download & upload
-.icon-download,
-.icon-upload {
+.#{$icon-prefix}-download,
+.#{$icon-prefix}-upload {
   border-bottom: $icon-border-width solid currentColor;
+
   &::before {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
@@ -297,6 +312,7 @@
     width: .5em;
     transform: translate(-50%, -60%) rotate(-135deg);
   }
+
   &::after {
     background: currentColor;
     content: "";
@@ -306,10 +322,11 @@
   }
 }
 
-.icon-upload {
+.#{$icon-prefix}-upload {
   &::before {
     transform: translate(-50%, -60%) rotate(45deg);
   }
+
   &::after {
     top: 50%;
   }

--- a/src/icons/_icons-core.scss
+++ b/src/icons/_icons-core.scss
@@ -1,7 +1,3 @@
-// Icon variables
-$icon-border-width: $border-width-lg;
-$icon-prefix: "icon";
-
 // Icon base style
 .#{$icon-prefix} {
   box-sizing: border-box;

--- a/src/icons/_icons-navigation.scss
+++ b/src/icons/_icons-navigation.scss
@@ -1,12 +1,12 @@
 // Icon arrows
-.icon-arrow-down,
-.icon-arrow-left,
-.icon-arrow-right,
-.icon-arrow-up,
-.icon-downward,
-.icon-back,
-.icon-forward,
-.icon-upward {
+.#{$icon-prefix}-arrow-down,
+.#{$icon-prefix}-arrow-left,
+.#{$icon-prefix}-arrow-right,
+.#{$icon-prefix}-arrow-up,
+.#{$icon-prefix}-downward,
+.#{$icon-prefix}-back,
+.#{$icon-prefix}-forward,
+.#{$icon-prefix}-upward {
   &::before {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
@@ -17,32 +17,32 @@
   }
 }
 
-.icon-arrow-down {
+.#{$icon-prefix}-arrow-down {
   &::before {
     transform: translate(-50%, -75%) rotate(225deg);
   }
 }
 
-.icon-arrow-left {
+.#{$icon-prefix}-arrow-left {
   &::before {
     transform: translate(-25%, -50%) rotate(-45deg);
   }
 }
 
-.icon-arrow-right {
+.#{$icon-prefix}-arrow-right {
   &::before {
     transform: translate(-75%, -50%) rotate(135deg);
   }
 }
 
-.icon-arrow-up {
+.#{$icon-prefix}-arrow-up {
   &::before {
     transform: translate(-50%, -25%) rotate(45deg);
   }
 }
 
-.icon-back,
-.icon-forward {
+.#{$icon-prefix}-back,
+.#{$icon-prefix}-forward {
   &::after {
     background: currentColor;
     content: "";
@@ -51,8 +51,8 @@
   }
 }
 
-.icon-downward,
-.icon-upward {
+.#{$icon-prefix}-downward,
+.#{$icon-prefix}-upward {
   &::after {
     background: currentColor;
     content: "";
@@ -61,44 +61,48 @@
   }
 }
 
-.icon-back {
+.#{$icon-prefix}-back {
   &::after {
     left: 55%;
   }
+
   &::before {
     transform: translate(-50%, -50%) rotate(-45deg);
   }
 }
 
-.icon-downward {
+.#{$icon-prefix}-downward {
   &::after {
     top: 45%;
   }
+
   &::before {
     transform: translate(-50%, -50%) rotate(-135deg);
   }
 }
 
-.icon-forward {
+.#{$icon-prefix}-forward {
   &::after {
     left: 45%;
   }
+
   &::before {
     transform: translate(-50%, -50%) rotate(135deg);
   }
 }
 
-.icon-upward {
+.#{$icon-prefix}-upward {
   &::after {
     top: 55%;
   }
+
   &::before {
     transform: translate(-50%, -50%) rotate(45deg);
   }
 }
 
 // Icon caret
-.icon-caret {
+.#{$icon-prefix}-caret {
   &::before {
     border-top: .3em solid currentColor;
     border-right: .3em solid transparent;
@@ -111,7 +115,7 @@
 }
 
 // Icon menu
-.icon-menu {
+.#{$icon-prefix}-menu {
   &::before {
     background: currentColor;
     box-shadow: 0 -.35em, 0 .35em;
@@ -122,7 +126,7 @@
 }
 
 // Icon apps
-.icon-apps {
+.#{$icon-prefix}-apps {
   &::before {
     background: currentColor;
     box-shadow: -.35em -.35em, -.35em 0, -.35em .35em, 0 -.35em, 0 .35em, .35em -.35em, .35em 0, .35em .35em;

--- a/src/icons/_icons-object.scss
+++ b/src/icons/_icons-object.scss
@@ -1,7 +1,8 @@
 // Icon time
-.icon-time {
+.#{$icon-prefix}-time {
   border: $icon-border-width solid currentColor;
   border-radius: 50%;
+
   &::before {
     background: currentColor;
     content: "";
@@ -9,6 +10,7 @@
     transform: translate(-50%, -75%);
     width: $icon-border-width;
   }
+
   &::after {
     background: currentColor;
     content: "";
@@ -20,7 +22,7 @@
 }
 
 // Icon mail
-.icon-mail {
+.#{$icon-prefix}-mail {
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: $border-radius;
@@ -28,6 +30,7 @@
     height: .8em;
     width: 1em;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-right: 0;
@@ -40,7 +43,7 @@
 }
 
 // Icon people
-.icon-people {
+.#{$icon-prefix}-people {
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: 50%;
@@ -49,6 +52,7 @@
     top: 25%;
     width: .45em;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-radius: 50% 50% 0 0;
@@ -60,11 +64,12 @@
 }
 
 // Icon message
-.icon-message {
+.#{$icon-prefix}-message {
   border: $icon-border-width solid currentColor;
   border-bottom: 0;
   border-radius: $border-radius;
   border-right: 0;
+
   &::before {
     border: $icon-border-width solid currentColor;
     border-bottom-right-radius: $border-radius;
@@ -76,6 +81,7 @@
     top: 40%;
     width: .7em;
   }
+
   &::after {
     background: currentColor;
     border-radius: $border-radius;
@@ -89,9 +95,10 @@
 }
 
 // Icon photo
-.icon-photo {
+.#{$icon-prefix}-photo {
   border: $icon-border-width solid currentColor;
   border-radius: $border-radius;
+
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: 50%;
@@ -101,6 +108,7 @@
     top: 35%;
     width: .25em;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-bottom: 0;
@@ -114,7 +122,7 @@
 }
 
 // Icon link
-.icon-link {
+.#{$icon-prefix}-link {
   &::before,
   &::after {
     border: $icon-border-width solid currentColor;
@@ -124,16 +132,18 @@
     height: .5em;
     width: .75em;
   }
+
   &::before {
     transform: translate(-70%, -45%) rotate(-45deg);
   }
+
   &::after {
     transform: translate(-30%, -55%) rotate(135deg);
   }
 }
 
 // Icon location
-.icon-location {
+.#{$icon-prefix}-location {
   &::before {
     border: $icon-border-width solid currentColor;
     border-radius: 50% 50% 50% 0;
@@ -142,6 +152,7 @@
     transform: translate(-50%, -60%) rotate(-45deg);
     width: .8em;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-radius: 50%;
@@ -153,9 +164,10 @@
 }
 
 // Icon emoji
-.icon-emoji {
+.#{$icon-prefix}-emoji {
   border: $icon-border-width solid currentColor;
   border-radius: 50%;
+
   &::before {
     border-radius: 50%;
     box-shadow: -.17em -.15em, .17em -.15em;
@@ -163,6 +175,7 @@
     height: .1em;
     width: .1em;
   }
+
   &::after {
     border: $icon-border-width solid currentColor;
     border-bottom-color: transparent;

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -3,22 +3,26 @@
   background: $color;
   border-color: darken($color, 3%);
   color: $light-color;
+
   &:focus {
     @include control-shadow($color);
   }
+
   &:focus,
   &:hover {
     background: darken($color, 2%);
     border-color: darken($color, 5%);
     color: $light-color;
   }
+
   &:active,
-  &.active {
+  &.#{$prefix}active {
     background: darken($color, 7%);
     border-color: darken($color, 10%);
     color: $light-color;
   }
-  &.loading {
+
+  &.#{$prefix}loading {
     &::after {
       border-bottom-color: $light-color;
       border-left-color: $light-color;
@@ -30,22 +34,26 @@
   background: $light-color;
   border-color: $color;
   color: $color;
+
   &:focus {
     @include control-shadow($color);
   }
+
   &:focus,
   &:hover {
     background: lighten($color, 50%);
     border-color: darken($color, 2%);
     color: $color;
   }
+
   &:active,
-  &.active {
+  &.#{$prefix}active {
     background: $color;
     border-color: darken($color, 5%);
     color: $light-color;
   }
-  &.loading {
+
+  &.#{$prefix}loading {
     &::after {
       border-bottom-color: $color;
       border-left-color: $color;

--- a/src/mixins/_color.scss
+++ b/src/mixins/_color.scss
@@ -1,5 +1,5 @@
 // Background color utility mixin
-@mixin bg-color-variant($name: ".bg-primary", $color: $primary-color) {
+@mixin bg-color-variant($name: ".#{$prefix}bg-primary", $color: $primary-color) {
   #{$name} {
     background: $color;
 
@@ -10,7 +10,7 @@
 }
 
 // Text color utility mixin
-@mixin text-color-variant($name: ".text-primary", $color: $primary-color) {
+@mixin text-color-variant($name: ".#{$prefix}text-primary", $color: $primary-color) {
   #{$name} {
     color: $color;
   }

--- a/src/mixins/_position.scss
+++ b/src/mixins/_position.scss
@@ -1,31 +1,31 @@
 // Margin utility mixin
 @mixin margin-variant($id: 1, $size: $unit-1) {
-  .m-#{$id} {
+  .#{$prefix}m-#{$id} {
     margin: $size;
   }
 
-  .mb-#{$id} {
+  .#{$prefix}mb-#{$id} {
     margin-bottom: $size;
   }
 
-  .ml-#{$id} {
+  .#{$prefix}ml-#{$id} {
     margin-left: $size;
   }
 
-  .mr-#{$id} {
+  .#{$prefix}mr-#{$id} {
     margin-right: $size;
   }
 
-  .mt-#{$id} {
+  .#{$prefix}mt-#{$id} {
     margin-top: $size;
   }
 
-  .mx-#{$id} {
+  .#{$prefix}mx-#{$id} {
     margin-left: $size;
     margin-right: $size;
   }
 
-  .my-#{$id} {
+  .#{$prefix}my-#{$id} {
     margin-bottom: $size;
     margin-top: $size;
   }
@@ -33,32 +33,32 @@
 
 // Padding utility mixin
 @mixin padding-variant($id: 1, $size: $unit-1) {
-  .p-#{$id} {
+  .#{$prefix}p-#{$id} {
     padding: $size;
   }
 
-  .pb-#{$id} {
+  .#{$prefix}pb-#{$id} {
     padding-bottom: $size;
   }
 
-  .pl-#{$id} {
+  .#{$prefix}pl-#{$id} {
     padding-left: $size;
   }
 
-  .pr-#{$id} {
+  .#{$prefix}pr-#{$id} {
     padding-right: $size;
   }
 
-  .pt-#{$id} {
+  .#{$prefix}pt-#{$id} {
     padding-top: $size;
   }
 
-  .px-#{$id} {
+  .#{$prefix}px-#{$id} {
     padding-left: $size;
     padding-right: $size;
   }
-  
-  .py-#{$id} {
+
+  .#{$prefix}py-#{$id} {
     padding-bottom: $size;
     padding-top: $size;
   }

--- a/src/spectre-icons.scss
+++ b/src/spectre-icons.scss
@@ -2,6 +2,11 @@
 @import "variables";
 @import "mixins";
 
+// Icon variables
+$icon-prefix: "icon";
+$icon-prefix: "#{$prefix}icon";
+$icon-border-width: $border-width-lg;
+
 /*! Spectre.css Icons v#{$version} | MIT License | github.com/picturepan2/spectre */
 // Icons
 @import "icons/icons-core";

--- a/src/utilities/_colors.scss
+++ b/src/utilities/_colors.scss
@@ -1,29 +1,29 @@
 // Text colors
-@include text-color-variant(".text-primary", $primary-color);
+@include text-color-variant(".#{$prefix}text-primary", $primary-color);
 
-@include text-color-variant(".text-secondary", $secondary-color-dark);
+@include text-color-variant(".#{$prefix}text-secondary", $secondary-color-dark);
 
-@include text-color-variant(".text-gray", $gray-color);
+@include text-color-variant(".#{$prefix}text-gray", $gray-color);
 
-@include text-color-variant(".text-light", $light-color);
+@include text-color-variant(".#{$prefix}text-light", $light-color);
 
-@include text-color-variant(".text-success", $success-color);
+@include text-color-variant(".#{$prefix}text-success", $success-color);
 
-@include text-color-variant(".text-warning", $warning-color);
+@include text-color-variant(".#{$prefix}text-warning", $warning-color);
 
-@include text-color-variant(".text-error", $error-color);
+@include text-color-variant(".#{$prefix}text-error", $error-color);
 
 // Background colors
-@include bg-color-variant(".bg-primary", $primary-color);
+@include bg-color-variant(".#{$prefix}bg-primary", $primary-color);
 
-@include bg-color-variant(".bg-secondary", $secondary-color);
+@include bg-color-variant(".#{$prefix}bg-secondary", $secondary-color);
 
-@include bg-color-variant(".bg-dark", $dark-color);
+@include bg-color-variant(".#{$prefix}bg-dark", $dark-color);
 
-@include bg-color-variant(".bg-gray", $bg-color);
+@include bg-color-variant(".#{$prefix}bg-gray", $bg-color);
 
-@include bg-color-variant(".bg-success", $success-color);
+@include bg-color-variant(".#{$prefix}bg-success", $success-color);
 
-@include bg-color-variant(".bg-warning", $warning-color);
+@include bg-color-variant(".#{$prefix}bg-warning", $warning-color);
 
-@include bg-color-variant(".bg-error", $error-color);
+@include bg-color-variant(".#{$prefix}bg-error", $error-color);

--- a/src/utilities/_cursors.scss
+++ b/src/utilities/_cursors.scss
@@ -1,24 +1,24 @@
 // Cursors
-.c-hand {
+.#{$prefix}c-hand {
   cursor: pointer;
 }
 
-.c-move {
+.#{$prefix}c-move {
   cursor: move;
 }
 
-.c-zoom-in {
+.#{$prefix}c-zoom-in {
   cursor: zoom-in;
 }
 
-.c-zoom-out {
+.#{$prefix}c-zoom-out {
   cursor: zoom-out;
 }
 
-.c-not-allowed {
+.#{$prefix}c-not-allowed {
   cursor: not-allowed;
 }
 
-.c-auto {
+.#{$prefix}c-auto {
   cursor: auto;
 }

--- a/src/utilities/_display.scss
+++ b/src/utilities/_display.scss
@@ -1,30 +1,30 @@
 // Display
-.d-block {
+.#{$prefix}d-block {
   display: block;
 }
-.d-inline {
+.#{$prefix}d-inline {
   display: inline;
 }
-.d-inline-block {
+.#{$prefix}d-inline-block {
   display: inline-block;
 }
-.d-flex {
+.#{$prefix}d-flex {
   display: flex;
 }
-.d-inline-flex {
+.#{$prefix}d-inline-flex {
   display: inline-flex;
 }
-.d-none,
-.d-hide {
+.#{$prefix}d-none,
+.#{$prefix}d-hide {
   display: none !important;
 }
-.d-visible {
+.#{$prefix}d-visible {
   visibility: visible;
 }
-.d-invisible {
+.#{$prefix}d-invisible {
   visibility: hidden;
 }
-.text-hide {
+.#{$prefix}text-hide {
   background: transparent;
   border: 0;
   color: transparent;
@@ -32,7 +32,7 @@
   line-height: 0;
   text-shadow: none;
 }
-.text-assistive {
+.#{$prefix}text-assistive {
   border: 0;
   clip: rect(0,0,0,0);
   height: 1px;

--- a/src/utilities/_divider.scss
+++ b/src/utilities/_divider.scss
@@ -1,13 +1,13 @@
 // Divider
-.divider,
-.divider-vert {
+.#{$prefix}divider,
+.#{$prefix}divider-vert {
   display: block;
   position: relative;
 
-  &[data-content]::after {
+  &[data-#{$prefix}content]::after {
     background: $bg-color-light;
     color: $gray-color;
-    content: attr(data-content);
+    content: attr(data-#{$prefix}content);
     display: inline-block;
     font-size: $font-size-sm;
     padding: 0 $unit-2;
@@ -15,17 +15,17 @@
   }
 }
 
-.divider {
+.#{$prefix}divider {
   border-top: $border-width solid $border-color;
   height: $border-width;
   margin: $unit-2 0;
 
-  &[data-content] {
+  &[data-#{$prefix}content] {
     margin: $unit-4 0;
   }
 }
 
-.divider-vert {
+.#{$prefix}divider-vert {
   display: block;
   padding: $unit-4;
 
@@ -40,7 +40,7 @@
     transform: translateX(-50%);
   }
 
-  &[data-content]::after {
+  &[data-#{$prefix}content]::after {
     left: 50%;
     padding: $unit-1 0;
     position: absolute;

--- a/src/utilities/_loading.scss
+++ b/src/utilities/_loading.scss
@@ -1,11 +1,12 @@
 // Loading
-.loading {
+.#{$prefix}loading {
   color: transparent !important;
   min-height: $unit-4;
   pointer-events: none;
   position: relative;
+
   &::after {
-    animation: loading 500ms infinite linear;
+    animation: #{$prefix}loading 500ms infinite linear;
     border: $border-width-lg solid $primary-color;
     border-radius: 50%;
     border-right-color: transparent;
@@ -22,8 +23,9 @@
     z-index: $zindex-0;
   }
 
-  &.loading-lg {
+  &.#{$prefix}loading-lg {
     min-height: $unit-10;
+
     &::after {
       height: $unit-8;
       margin-left: -$unit-4;

--- a/src/utilities/_position.scss
+++ b/src/utilities/_position.scss
@@ -1,36 +1,36 @@
 // Position
-.clearfix {
+.#{$prefix}clearfix {
   @include clearfix();
 }
 
-.float-left {
+.#{$prefix}float-left {
   float: left !important;
 }
 
-.float-right {
+.#{$prefix}float-right {
   float: right !important;
 }
 
-.relative {
+.#{$prefix}relative {
   position: relative;
 }
 
-.absolute {
+.#{$prefix}absolute {
   position: absolute;
 }
 
-.fixed {
+.#{$prefix}fixed {
   position: fixed;
 }
 
-.centered {
+.#{$prefix}centered {
   display: block;
   float: none;
   margin-left: auto;
   margin-right: auto;
 }
 
-.flex-centered {
+.#{$prefix}flex-centered {
   align-items: center;
   display: flex;
   justify-content: center;

--- a/src/utilities/_shapes.scss
+++ b/src/utilities/_shapes.scss
@@ -1,8 +1,8 @@
 // Shapes
-.rounded {
+.#{$prefix}rounded {
   border-radius: $border-radius;
 }
 
-.circle {
+.#{$prefix}circle {
   border-radius: 50%;
 }

--- a/src/utilities/_text.scss
+++ b/src/utilities/_text.scss
@@ -1,63 +1,63 @@
 // Text
 // Text alignment utilities
-.text-left {
+.#{$prefix}text-left {
   text-align: left;
 }
 
-.text-right {
+.#{$prefix}text-right {
   text-align: right;
 }
 
-.text-center {
+.#{$prefix}text-center {
   text-align: center;
 }
 
-.text-justify {
+.#{$prefix}text-justify {
   text-align: justify;
 }
 
 // Text transform utilities
-.text-lowercase {
+.#{$prefix}text-lowercase {
   text-transform: lowercase;
 }
 
-.text-uppercase {
+.#{$prefix}text-uppercase {
   text-transform: uppercase;
 }
 
-.text-capitalize {
+.#{$prefix}text-capitalize {
   text-transform: capitalize;
 }
 
 // Text style utilities
-.text-normal {
+.#{$prefix}text-normal {
   font-weight: normal;
 }
 
-.text-bold {
+.#{$prefix}text-bold {
   font-weight: bold;
 }
 
-.text-italic {
+.#{$prefix}text-italic {
   font-style: italic;
 }
 
-.text-large {
+.#{$prefix}text-large {
   font-size: 1.2em;
 }
 
 // Text overflow utilities
-.text-ellipsis {
+.#{$prefix}text-ellipsis {
   @include text-ellipsis();
 }
 
-.text-clip {
+.#{$prefix}text-clip {
   overflow: hidden;
   text-overflow: clip;
   white-space: nowrap;
 }
 
-.text-break {
+.#{$prefix}text-break {
   hyphens: auto;
   word-break: break-word;
   word-wrap: break-word;


### PR DESCRIPTION
This PR solves #418 with an optional `$prefix` variable that defaults to empty string. 

It was inspired and extends usage of the `$icon-prefix` that was established in `icons/icon-core` but was never actually used. It is now.

This provides additional compatibility and usage in existing projects without extra effort. It also has no impact on existing users as the generated output shows. The two changes in the output are whitespace only and I'm not sure why they show up at all.

I appreciate all the work that went into this project. While working on this PR I learned a lot about the inner workings.

While I'd love to see this in the official Spectre build, I do understand that it might not be to everybody's taste, but I thought this could be worth a shot.

**Edit:** I found some missing prefixes while working with this branch in one of my projects and fixed those errors. Will rebase when requested.