### PR TITLE
Match form input/option element background colours to the overall the…

### DIFF
--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -118,7 +118,7 @@ textarea.form-input {
   padding: $control-padding-y $control-padding-x;
   vertical-align: middle;
   width: 100%;
-
+  background: $bg-color-light; 
   &[size],
   &[multiple] {
     height: auto;
@@ -128,7 +128,7 @@ textarea.form-input {
     }
   }
   &:not([multiple]):not([size]) {
-    background: #fff url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center/.4rem .5rem;
+    background: $bg-color-light url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center/.4rem .5rem;
     padding-right: $control-icon-size + $control-padding-x;
   }
   &:focus {


### PR DESCRIPTION
I'm a total CSS n00b, however there was a hardcoded #fff for a background colour and an absent background: specifier which made my darker theme impossible to read the text inside of a form. 