### PR TITLE
Fix sidebar background height for short docs pages

### DIFF
--- a/docs/src/scss/docs.scss
+++ b/docs/src/scss/docs.scss
@@ -24,6 +24,10 @@
   }
 }
 
+.docs-container {
+  min-height: 100vh;
+}
+
 .docs-navbar {
   height: 3.8rem;
   position: fixed;


### PR DESCRIPTION
The sidebar background did not cover the whole navigation when the page content was shorten than window height.