### PR TITLE
Add HTML5 crossorigin attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Download the compiled and minified [Spectre CSS files](https://github.com/pictur
 ### Install from CDN
 Alternatively, you can use the [unpkg](https://unpkg.com/) or [cdnjs](https://cdnjs.com/libraries/spectre.css) CDN to load compiled Spectre.css.
 
-`<link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre.min.css">`
+`<link rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre.min.css" crossorigin="anonymous">`
 
 ### Install with NPM
 `$ npm install spectre.css --save`


### PR DESCRIPTION
In suggested code to copy and paste, load spectre.css from CDNs without sending user-credentials.
Verified
