### PR TITLE
Fixed #478

### DIFF
--- a/src/_tooltips.scss
+++ b/src/_tooltips.scss
@@ -97,7 +97,7 @@
 
   &.tooltip-bottom-left,
   &.tooltip-top-left {
-    &::after{
+    &::after {
       left: -$border-width;
       right: auto;
     }
@@ -105,7 +105,7 @@
 
   &.tooltip-bottom-right,
   &.tooltip-top-right {
-    &::after{
+    &::after {
       left: auto;
       right: -$border-width;
     }

--- a/src/_tooltips.scss
+++ b/src/_tooltips.scss
@@ -76,4 +76,38 @@
       }
     }
   }
+
+  &[class*="tooltip-top-"] {
+    &::after {
+      transform: translate(0, -$unit-1);
+    }
+  }
+
+  &[class*="tooltip-bottom-"] {
+    &::after {
+      transform: translate(0, $unit-1);
+    }
+    &:focus,
+    &:hover {
+      &::after {
+        transform: translate(0, $unit-1);
+      }
+    }
+  }
+
+  &.tooltip-bottom-left,
+  &.tooltip-top-left {
+    &::after{
+      left: -$border-width;
+      right: auto;
+    }
+  }
+
+  &.tooltip-bottom-right,
+  &.tooltip-top-right {
+    &::after{
+      left: auto;
+      right: -$border-width;
+    }
+  }
 }


### PR DESCRIPTION
Add feature to fixed tooltips and popovers run off the edge of the screen #478 

```
<button class="btn tooltip tooltip-top-left" data-tooltip="Tooltip">top tooltip</button>
<button class="btn tooltip tooltip-top-right" data-tooltip="Tooltip">top tooltip</button>
<button class="btn tooltip tooltip-bottom tooltip-bottom-left" data-tooltip="Tooltip">bottom tooltip</button>
<button class="btn tooltip tooltip-bottom tooltip-bottom-right" data-tooltip="Tooltip">bottom tooltip</button>
```