### PR TITLE
docs/navbar.pug: fix example documentation

### DIFF
--- a/docs/src/layout/navbar.pug
+++ b/docs/src/layout/navbar.pug
@@ -33,7 +33,7 @@ block docs-content
         :highlight(lang="html")
           <header class="navbar">
             <section class="navbar-section">
-              <a href="..." class="navbar-brand mr-2">Spectre.css</a>
+              <a href="..." class="navbar-brand text-bold mr-2">SPECTRE.CSS</a>
               <a href="..." class="btn btn-link">Docs</a>
               <a href="..." class="btn btn-link">GitHub</a>
             </section>


### PR DESCRIPTION
The example for navbar was misleading as the code shown in the documentation
does not match with the navbar demo shown above.