### PR TITLE
Fixes for buttons

### DIFF
--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -18,7 +18,7 @@
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  font-weight:normal;
+  font-weight: normal;
   &:focus {
     @include control-shadow();
   }

--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -162,9 +162,11 @@ a {
     &:hover {
       color: $primary-color;
     }
+    
     &:active {
       color: $light-color;
     }
+    
     &.btn-primary,
     &.btn-error,
     &.btn-success {

--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -156,6 +156,26 @@
   }
 }
 
+a {
+  &.btn {
+    &:visited,
+    &:hover {
+      color: $primary-color;
+    }
+    &:active {
+      color: $light-color;
+    }
+    &.btn-primary,
+    &.btn-error,
+    &.btn-success {
+      &:visited,
+      &:hover {
+        color: $light-color;
+      }
+    }
+  }
+}
+
 // Button groups
 .btn-group {
   display: inline-flex;

--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -18,6 +18,7 @@
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
+  font-weight:normal;
   &:focus {
     @include control-shadow();
   }


### PR DESCRIPTION
There has been a few issues when applying the .btn class. 
First of all in some browsers (in my case Firefox on Solus OS) the buttons by default in the browser are getting bold. This made the `button.btn` looking different then `a.btn`. Buttons were bold and links not. I applied `font-weight:normal` to all elements with `.btn class`
Second issue was with the `a.btn` elements when they were visited. They color was taken from the styles of a:visited so it was changing the color of the button. I don't think it's desired behavior. I have overriden it by adding the `a.btn:visited` rules.