### PR TITLE
Fixed #567 - the alignment of .btn-group with .btn

### DIFF
--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -159,6 +159,7 @@
 .btn-group {
   display: inline-flex;
   flex-wrap: wrap;
+  vertical-align: middle;
 
   .btn {
     flex: 1 0 auto;


### PR DESCRIPTION
Fixed issue with alignment of button group with button. The change was only
setting the vertical-alignment of the button group to middle.