### PR TITLE
Fix range input slider styles in Internet Explorer

### DIFF
--- a/src/_sliders.scss
+++ b/src/_sliders.scss
@@ -6,6 +6,7 @@
   display: block;
   width: 100%;
   height: $unit-6;
+  padding: 0;
 
   &:focus {
     @include control-shadow();
@@ -89,7 +90,9 @@
   }
   &::-ms-track {
     background: $bg-color-dark;
+    border: 0;
     border-radius: $border-radius;
+    color: transparent;
     height: $unit-h;
     width: 100%;
   }


### PR DESCRIPTION
The experimental Sliders component does not currently render in Internet Explorer. This pull request fixes the style issues in Internet Explorer.

I only had to add three lines of code, here are the details on what the code I added actually does:
```
.slider {
	// Remove default padding which causes the slider to be clipped out
	// https://stackoverflow.com/a/45665242
	padding: 0;

	&::-ms-track {
		// Remove default black border
		border: 0;

		// Remove default black tickmarks
		// https://stackoverflow.com/a/56599481
		color: transparent;
	}
}
```
