### PR TITLE
Make column classes less verbose

### DIFF
--- a/docs/utilities/text.html
+++ b/docs/utilities/text.html
@@ -234,8 +234,15 @@
 <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"text-bold"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
 <span class="hljs-comment">&lt;!-- Italicized text --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"text-italic"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+<span class="hljs-comment">&lt;!-- Muted text --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"text-muted"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
 <span class="hljs-comment">&lt;!-- Larger text (120%) --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"text-large"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+<span class="hljs-comment">&lt;!-- Smaller text (90%) --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"text-small"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+<span class="hljs-comment">&lt;!-- Tiny text (80%) --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"text-tiny"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+
 
 <span class="hljs-comment">&lt;!-- Overflow behavior: display an ellipsis to represent clipped text --&gt;</span>
 <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">class</span>=<span class="hljs-string">"text-ellipsis"</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>

--- a/src/_layout.scss
+++ b/src/_layout.scss
@@ -39,6 +39,7 @@
 }
 
 // Responsive grid system
+.cols,
 .columns {
   display: flex;
   flex-wrap: wrap;
@@ -59,6 +60,7 @@
     overflow-x: auto;
   }
 }
+[class~="col-"],
 .column {
   flex: 1;
   max-width: 100%;

--- a/src/utilities/_text.scss
+++ b/src/utilities/_text.scss
@@ -47,15 +47,15 @@
 }
 
 .text-small {
-    font-size: 0.9em;
+  font-size: .9em;
 }
 
 .text-tiny {
-    font-size: 0.8em;
+  font-size: .8em;
 }
 
 .text-muted {
-    opacity: 0.8;
+  opacity: .8;
 }
 
 // Text overflow utilities

--- a/src/utilities/_text.scss
+++ b/src/utilities/_text.scss
@@ -46,6 +46,18 @@
   font-size: 1.2em;
 }
 
+.text-small {
+    font-size: 0.9em;
+}
+
+.text-tiny {
+    font-size: 0.8em;
+}
+
+.text-muted {
+    opacity: 0.8;
+}
+
 // Text overflow utilities
 .text-ellipsis {
   @include text-ellipsis();


### PR DESCRIPTION
.cols shorthand for .columns
[class~="col-"] Removes the need to always type 'column' in the column class attribute