### PR TITLE
Allow dragging on comparison-slider dots

### DIFF
--- a/src/_comparison-sliders.scss
+++ b/src/_comparison-sliders.scss
@@ -63,6 +63,7 @@
       top: 50%;
       transform: translate(50%, -50%);
       width: 3px;
+      pointer-events: none;
     }
 
     .comparison-label {


### PR DESCRIPTION
Currently, the comparison slider cannot be resized when the mouse is over the three dots.

Example of the issue happening:
![ezgif com-optimize (9)](https://user-images.githubusercontent.com/105127/73102436-dadfd800-3ebf-11ea-95b4-2c2e2dc5396f.gif)
