### PR TITLE
simplify contributions by fully automating the dev setup with gitpod.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 !.gitattributes
 !.hound.yml
 !.scss-lint.yml
+!.gitpod.yml

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: yarn install

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Alternatively, you can use the [unpkg](https://unpkg.com/) or [cdnjs](https://cd
 
 You can compile your custom version of Spectre.css. Read [the documentation](https://picturepan2.github.io/spectre/getting-started/custom.html).
 
+## Contributing
+
+### Online one-click setup
+
+You can use Gitpod(a free online VS Code-like IDE) for contributing. With a single-click it'll launch a workspace and automatically:
+
+- clone the repo.
+- install the dependencies.
+
+so that you can start coding straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Documentation and examples
 
 ### Elements


### PR DESCRIPTION
This Pr simplifies code contributions by fully automating the dev setup with Gitpod(A free online VS Code like IDE).

With a single click, it'll launch a workspace  and automatically:

- clone the spectre repo.
- install the dependencies.

So that anyone interested in contributing can start coding straight away.

You can give it a try on my fork of the repo via the link below:

https://gitpod.io/#https://github.com/nisarhassan12/spectre

![image](https://user-images.githubusercontent.com/46004116/74811166-c2be7580-5312-11ea-9a04-33c42f4db973.png)
