### PR TITLE
Fix issue #274 - Add column order classes

### DIFF
--- a/src/_columns-order.scss
+++ b/src/_columns-order.scss
@@ -1,0 +1,58 @@
+// Columns order
+@for $i from 1 through $columns-count {
+  .order-#{$i} { -ms-flex-order: $i; order: $i; }
+}
+@media (max-width:($size-xs)) {
+  @for $i from 1 through $columns-count {
+    .order-#{$i} { -ms-flex-order: $i; order: $i; }
+    .order-xs-#{$i} {
+      -ms-flex-order: #{$i};
+      order: #{$i};
+    }
+  }
+}
+@media (max-width:($size-sm)) {
+  @for $i from 1 through $columns-count {
+    .order-#{$i} { -ms-flex-order: $i; order: $i; }
+    .order-sm-#{$i} {
+      -ms-flex-order: #{$i};
+      order: #{$i};
+    }
+  }
+}
+@media (max-width:($size-md)) {
+  @for $i from 1 through $columns-count {
+    .order-#{$i} { -ms-flex-order: $i; order: $i; }
+    .order-md-#{$i} {
+      -ms-flex-order: #{$i};
+      order: #{$i};
+    }
+  }
+}
+@media (max-width:($size-lg)) {
+  @for $i from 1 through $columns-count {
+    .order-#{$i} { -ms-flex-order: $i; order: $i; }
+    .order-lg-#{$i} {
+      -ms-flex-order: #{$i};
+      order: #{$i};
+    }
+  }
+}
+@media (max-width:($size-xl)) {
+  @for $i from 1 through $columns-count {
+    .order-#{$i} { -ms-flex-order: $i; order: $i; }
+    .order-xl-#{$i} {
+      -ms-flex-order: #{$i};
+      order: #{$i};
+    }
+  }
+}
+@media (max-width:($size-2x)) {
+  @for $i from 1 through $columns-count {
+    .order-#{$i} { -ms-flex-order: $i; order: $i; }
+    .order-2x-#{$i} {
+      -ms-flex-order: #{$i};
+      order: #{$i};
+    }
+  }
+}

--- a/src/_columns-order.scss
+++ b/src/_columns-order.scss
@@ -2,6 +2,7 @@
 @for $i from 1 through $columns-count {
   .order-#{$i} { -ms-flex-order: $i; order: $i; }
 }
+
 @media (max-width:($size-xs)) {
   @for $i from 1 through $columns-count {
     .order-#{$i} { -ms-flex-order: $i; order: $i; }
@@ -11,6 +12,7 @@
     }
   }
 }
+
 @media (max-width:($size-sm)) {
   @for $i from 1 through $columns-count {
     .order-#{$i} { -ms-flex-order: $i; order: $i; }
@@ -20,6 +22,7 @@
     }
   }
 }
+
 @media (max-width:($size-md)) {
   @for $i from 1 through $columns-count {
     .order-#{$i} { -ms-flex-order: $i; order: $i; }
@@ -29,6 +32,7 @@
     }
   }
 }
+
 @media (max-width:($size-lg)) {
   @for $i from 1 through $columns-count {
     .order-#{$i} { -ms-flex-order: $i; order: $i; }
@@ -38,6 +42,7 @@
     }
   }
 }
+
 @media (max-width:($size-xl)) {
   @for $i from 1 through $columns-count {
     .order-#{$i} { -ms-flex-order: $i; order: $i; }
@@ -47,6 +52,7 @@
     }
   }
 }
+
 @media (max-width:($size-2x)) {
   @for $i from 1 through $columns-count {
     .order-#{$i} { -ms-flex-order: $i; order: $i; }

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -99,6 +99,9 @@ $control-width-md: 640px !default;
 $control-width-lg: 960px !default;
 $control-width-xl: 1280px !default;
 
+// Max Columns number
+$columns-count: 12;
+
 // Responsive breakpoints
 $size-xs: 480px !default;
 $size-sm: 600px !default;

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -100,7 +100,7 @@ $control-width-lg: 960px !default;
 $control-width-xl: 1280px !default;
 
 // Max Columns number
-$columns-count: 12;
+$columns-count: 4;
 
 // Responsive breakpoints
 $size-xs: 480px !default;


### PR DESCRIPTION
Hi,
First of all: thank you for this nice framework, I use it since 3 years and I like it !
A few months ago I needed this feature on a project where I extend spectre for a custom starting theme for Drupal 7/8 so I created a new file that provide columns order functionalities:

- add classes from "order-1" to "order-12" to order columns on different pages
- add classes for every breakpoints defined in spectre to change columns order, i.e. "order-md-1", "order-md-2" or "order-lg-1", "order-lg-2", etc.

**Remarks**: using both order-N and order-BP-N (where N is the column number and BP is the breakpoint abbr.) on the same element does not work as order-N take advantage on order-BP-N

If you want to include it in spectre...