### PR TITLE
make loading element position important

### DIFF
--- a/src/utilities/_loading.scss
+++ b/src/utilities/_loading.scss
@@ -14,13 +14,13 @@
     content: "";
     display: block;
     height: $unit-4;
-    left: 50%;
+    left: 50% !important; // !important fixes https://github.com/picturepan2/spectre/issues/649
     margin-left: -$unit-2;
     margin-top: -$unit-2;
     opacity: 1;
     padding: 0;
     position: absolute;
-    top: 50%;
+    top: 50% !important; // !important fixes https://github.com/picturepan2/spectre/issues/649
     width: $unit-4;
     z-index: $zindex-0;
   }


### PR DESCRIPTION
When the `.loading` class is applied to a `.tooltip`, the loading element is wrongly positioned. This is due to the `left` and `top` rules in the `.tooltip::after` class.

Solution to this issue is to set `!important` to `left` and `top` rules in the `.loading::after` class.

Fixes #649 