### PR TITLE
Add top border to tables that do not have a <thead> element

### DIFF
--- a/src/_tables.scss
+++ b/src/_tables.scss
@@ -54,4 +54,11 @@
   th {
     border-bottom-width: $border-width-lg;
   }
+
+  // Add top border on tables without a <thead>
+  tbody:first-child {
+    td {
+      border-top: $border-width solid $border-color;
+    }
+  }
 }


### PR DESCRIPTION
Consider a table without a `thead`, such as:

```html
<table class="table">
  <tbody>
    <tr>
      <td>The Shawshank Redemption</td>
      <td>Crime, Drama</td>
      <td>14 October 1994</td>
    </tr>
    <tr>
      <td>The Godfather</td>
      <td>Crime, Drama</td>
      <td>24 March 1972</td>
    </tr>
    <tr>
      <td>Schindler's List</td>
      <td>Biography, Drama, History</td>
      <td>4 February 1994</td>
    </tr>
    <tr>
      <td>Se7en</td>
      <td>Crime, Drama, Mystery</td>
      <td>22 September 1995</td>
    </tr>
  </tbody>
</table>
```

In this case, Spectre will not add a border to the top row, as the
corresponding CSS only defines bottom borders:

<img width="811" alt="Screenshot 2020-12-16 at 11 51 38" src="https://user-images.githubusercontent.com/2192773/102374080-50044200-3f97-11eb-81a7-d705ea8d5cc1.png">

This fix adds the top border if there is no `thead` element (i.e.
`tbody` is the first child of the table).

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>