### PR TITLE
Fix bad padding on .off-canvas-content

### DIFF
--- a/src/_off-canvas.scss
+++ b/src/_off-canvas.scss
@@ -42,7 +42,7 @@ $off-canvas-breakpoint: $size-lg !default;
   .off-canvas-content {
     flex: 1 1 auto;
     height: 100%;
-    padding: $layout-spacing $layout-spacing $layout-spacing 4rem;
+    padding: $layout-spacing $layout-spacing $layout-spacing $layout-spacing;
   }
 
   .off-canvas-overlay {


### PR DESCRIPTION
The padding was misconfigured, which looked very weird, especially on phone.
Before :
![firefox_FcFF6hh5ac](https://user-images.githubusercontent.com/72203260/102694104-3543fe80-421f-11eb-8011-a6d5176b148a.png)
After :
![firefox_dW8P2qEoxz](https://user-images.githubusercontent.com/72203260/102694108-412fc080-421f-11eb-986d-7c1731010eb3.png)