### PR TITLE
Fix form-select color

### DIFF
--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -114,7 +114,7 @@ textarea.form-input {
   appearance: none;
   border: $border-width solid $border-color-dark;
   border-radius: $border-radius;
-  color: inherit;
+  color: $body-font-color;
   font-size: $font-size;
   height: $control-size;
   line-height: $line-height;


### PR DESCRIPTION
When using a dark theme with a light color, the select field will also have this color. Other input fields do not have this issue, as they use `color: $body-font-color;` instead. I've adapted that style.

This was initial set in this commit, I am wondering, why this change was made:
https://github.com/picturepan2/spectre/commit/4b7f4493bb078f70236345ff045be9da34629ce9