### PR TITLE
Add a configuration file for creating a Dash docset

### DIFF
--- a/docs/dashing.json
+++ b/docs/dashing.json
@@ -1,0 +1,20 @@
+{
+	"name": "Spectre.css",
+	"package": "spectre",
+	"index": "getting-started.html",
+	"selectors": {
+		"h3.s-title": {
+			"type": "Component",
+			"regexp": "#",
+			"replacement": ""
+		},
+		"h4.s-subtitle": {
+			"type": "Section",
+			"regexp": "#",
+			"replacement": ""
+		}
+	},
+	"icon32x32": "img/favicons/favicon.png",
+	"allowJS": true,
+	"ExternalURL": "https://picturepan2.github.io/spectre/"
+}


### PR DESCRIPTION
This is a configuration file for the docs generator [dashing](https://github.com/technosophos/dashing) for the [macOS offline documentation browser Dash](https://kapeli.com/dash). 

To build the docset, you'd run install dashing [like described](https://github.com/technosophos/dashing) and run the command:
```
dashing build spectre
```

[A new docset could be submitted](https://github.com/Kapeli/Dash-User-Contributions#contribute-a-new-docset) through this, or you can just double click it to directly add it to Dash.

